### PR TITLE
find and memoize address on call rather than init

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 0.1.3"}
+    {:signet, "~> 0.1.4"}
   ]
 end
 ```

--- a/lib/signet/test/signer.ex
+++ b/lib/signet/test/signer.ex
@@ -21,8 +21,6 @@ defmodule Signet.Test.Signer do
       name: name
     )
 
-    GenServer.cast(name, :set_address)
-
     name
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Since race conditions on setup of the credentials processes are tough, we change to fetch address from the credentials server lazily.