### PR TITLE
Add Base Fee & Priority Fee Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * 0.1.7
   - Move support libs to conditional compilation
+  - Add estimate gas price support
 * 0.1.6 - Make CloudKMS truly optional
 * 0.1.5 - Add build-in Solidity error decoding, fix warnings, bump to 0.1.5
 * 0.1.4 - Memoize versus preload address for signers

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 0.1.6"}
+    {:signet, "~> 0.1.7"}
   ]
 end
 ```
@@ -191,7 +191,7 @@ You can also pass in known Solidity errors, to have them decoded for you, e.g.:
 Finally, `execute_trx` is similar to sending transactions with Web3, which will pull a nonce and estimate gas, before submitting the transaction to the Ethereum node:
 
 ```elixir
-{:ok, trx_id} = Signet.RPC.execute_trx(<<1::160>>, {"baz(uint,address)", [50, <<1::160>> |> :binary.decode_unsigned]}, gas_price: {50, :gwei}, gas_limit: 100_000, value: 0, nonce: 10)
+{:ok, trx_id} = Signet.RPC.execute_trx(<<1::160>>, {"baz(uint,address)", [50, <<1::160>> |> :binary.decode_unsigned]}, priority_fee: {2, :gwei}, gas_limit: 100_000, value: 0, nonce: 10)
 ```
 
 Note: due to our ABI encoder, addresses should be passed in as `unsigned`s, not binaries.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "0.1.6",
+      version: "0.1.7",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/lib/client.ex
+++ b/test/lib/client.ex
@@ -45,6 +45,10 @@ defmodule Signet.Test.Client do
     "0x4"
   end
 
+  def eth_gasPrice() do
+    "0x3b9aca00" # 1 gwei
+  end
+
   def eth_sendRawTransaction(trx_enc) do
     {:ok, trx} =
       trx_enc


### PR DESCRIPTION
This patch starts to add support to building a transaction based on base fee and priority fee. These are the first changes to start to make Signet compliant with EIP-1559, but we still currently add the fees together and wrap them in a Legacy transaction. This will more or less give the same functionality as users should specify `priority_fee` and let the base fee be handled by the protocol.

Note: this isn't great since we add a 20% buffer to the base fee that _becomes_ a priority fee. We'll fix this in future upgrades.