### PR TITLE
Handle Non-EIP-155 Signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* 0.1.8
+  - Support non-EIP-155 signature recovery
 * 0.1.7
   - Move support libs to conditional compilation
   - Add estimate gas price support

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 0.1.7"}
+    {:signet, "~> 0.1.8"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "0.1.7",
+      version: "0.1.8",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
According to [EIP-155](https://eips.ethereum.org/EIPS/eip-155), signatures for Ethereum transactions or messages use a recovery bit that is `35 + chain_id * 2 + rec_id`, which we took to mean an odd recovery bit would mean the original rec_id was 0, and an even would mean the original rec_id was 1. But when hardware wallets and other people sign and don't follow EIP-155, then 0 should still imply a rec_id of 0, and 1 should still imply a rec_id of 1, and thus we add explicit support for that in this patch.