### PR TITLE
Add EIP-155 Signature Helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* 0.1.9
+  - Add EIP-155 signature helpers
+  - Logo and readme improvements
 * 0.1.8
   - Support non-EIP-155 signature recovery
 * 0.1.7

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 0.1.8"}
+    {:signet, "~> 0.1.9"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "0.1.8",
+      version: "0.1.9",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -1,4 +1,5 @@
 defmodule Signet.UtilTest do
   use ExUnit.Case, async: true
   doctest Signet.Util
+  doctest Signet.Util.RecoveryBit
 end


### PR DESCRIPTION
This patch adds a bunch of minor functions to help with EIP-155-type signatures. Ethereum has multiple ways of passing through a recovery bit. Either 0,1, or 27,28, or `35+chain_id*2+{0,1}`. We make it seamless to convert between these for signatures.