### PR TITLE
Add Publish from Releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hayesgm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache Build
+        uses: actions/cache@v3
+        with:
+          path: _build
+          key: ${{ runner.os }}-build
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "25.0"
+          elixir-version: "1.13.4"
+
+      - name: Elixir Dependencies
+        run: mix deps.get
+
+      - name: Mix Compile
+        run: mix compile
+
+      - name: Run Tests
+        run: mix test
+
+      - name: Publish to Hex
+        uses: synchronal/hex-publish-action@v1
+        with:
+          name: circlex_api
+          key: ${{ secrets.HEX_PM_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,47 @@
-# Changelog
+## v0.1.10
 
-* 0.1.9
-  - Add EIP-155 signature helpers
-  - Logo and readme improvements
-* 0.1.8
-  - Support non-EIP-155 signature recovery
-* 0.1.7
-  - Move support libs to conditional compilation
-  - Add estimate gas price support
-* 0.1.6 - Make CloudKMS truly optional
-* 0.1.5 - Add build-in Solidity error decoding, fix warnings, bump to 0.1.5
-* 0.1.4 - Memoize versus preload address for signers
-* 0.1.3 - Add RPC option for timeout, increase default to 30s
-* 0.1.2
-  - Include a built-in Erc20 contract implementation
-  - Allow 0 to specify not including an EIP-155 signature
-  - Add a simple contract address translation function
-* 0.1.1 - Add Ethereum Keypair Generation
-* 0.1.0 - Initial version
+- Add simple auto-publish mechanism
+
+## v0.1.9
+
+- Add EIP-155 signature helpers
+- Logo and readme improvements
+
+## v0.1.8
+
+- Support non-EIP-155 signature recovery
+
+## v0.1.7
+
+- Move support libs to conditional compilation
+- Add estimate gas price support
+
+## v0.1.6
+
+- Make CloudKMS truly optional
+
+## v0.1.5
+
+- Add build-in Solidity error decoding, fix warnings, bump to 0.1.5
+
+## 0.1.4
+
+- Memoize versus preload address for signers
+
+## 0.1.3
+
+- Add RPC option for timeout, increase default to 30s
+
+## 0.1.2
+
+- Include a built-in Erc20 contract implementation
+- Allow 0 to specify not including an EIP-155 signature
+- Add a simple contract address translation function
+
+## 0.1.1
+
+- Add Ethereum Keypair Generation
+
+## 0.1.0
+
+- Initial version

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 0.1.9"}
+    {:signet, "~> 0.1.10"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "0.1.9",
+      version: "0.1.10",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch adds the ability to auto-public to Hex when a new release is created. This should simplify the flow for pushing new versions.