### PR TITLE
Add `trace_transaction` Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 0.1.10"}
+    {:signet, "~> 0.2.0"}
   ]
 end
 ```
@@ -205,6 +205,12 @@ You can pull a transaction receipt via:
 
 ```elixir
 {:ok, receipt} = Signet.RPC.get_trx_receipt(trx_id)
+```
+
+You can pull a transaction traces via:
+
+```elixir
+{:ok, trace} = Signet.RPC.trace_transaction(trx_id)
 ```
 
 ### Filtering

--- a/lib/signet/trace.ex
+++ b/lib/signet/trace.ex
@@ -1,0 +1,220 @@
+defmodule Signet.Trace do
+  @moduledoc ~S"""
+  Represents an Ethereum transaction trace, which contains information
+  about the call graph of an executed transaction.
+
+  See `Signet.RPC.trace_transaction` for getting traces from
+  an Ethereum JSON-RPC host.
+
+  See also:
+    * Alcemy docs: https://docs.alchemy.com/reference/trace-transaction
+    * Infura docs: https://docs.infura.io/networks/ethereum/json-rpc-methods/trace-methods/trace_transaction
+    * Infura trace object: https://docs.infura.io/networks/ethereum/json-rpc-methods/trace-methods/#trace
+  """
+
+  defmodule Action do
+    @type t() :: %__MODULE__{
+            call_type: String.t(),
+            from: <<_::160>>,
+            gas: integer(),
+            input: binary(),
+            to: <<_::160>>,
+            value: integer()
+          }
+
+    defstruct [
+      :call_type,
+      :from,
+      :gas,
+      :input,
+      :to,
+      :value
+    ]
+
+    @doc ~S"""
+    Deserializes a trace sub-action into a struct.
+
+    ## Examples
+
+        iex> %{
+        ...>   "callType" => "call",
+        ...>   "from" => "0x83806d539d4ea1c140489a06660319c9a303f874",
+        ...>   "gas" => "0x1a1f8",
+        ...>   "input" => "0x",
+        ...>   "to" => "0x1c39ba39e4735cb65978d4db400ddd70a72dc750",
+        ...>   "value" => "0x7a16c911b4d00000"
+        ...> }
+        ...> |> Signet.Trace.Action.deserialize()
+        %Signet.Trace.Action{
+          call_type: "call",
+          from: Signet.Util.decode_hex!("0x83806d539d4ea1c140489a06660319c9a303f874"),
+          gas: 0x01a1f8,
+          input: <<>>,
+          to: Signet.Util.decode_hex!("0x1c39ba39e4735cb65978d4db400ddd70a72dc750"),
+          value: 0x7a16c911b4d00000,
+        }
+    """
+    @spec deserialize(map()) :: t() | no_return()
+    def deserialize(params = %{"callType" => call_type}) when is_binary(call_type) do
+      %__MODULE__{
+        call_type: call_type,
+        from: Signet.Util.decode_address!(params["from"]),
+        gas: Signet.Util.decode_hex_number!(params["gas"]),
+        input: Signet.Util.decode_hex!(params["input"]),
+        to: Signet.Util.decode_address!(params["to"]),
+        value: Signet.Util.decode_hex_number!(params["value"])
+      }
+    end
+  end
+
+  @type t() :: %__MODULE__{
+          action: Action.t(),
+          block_hash: <<_::256>>,
+          block_number: integer(),
+          gas_used: integer(),
+          output: binary(),
+          subtraces: integer(),
+          trace_address: <<_::160>>,
+          transaction_hash: <<_::256>>,
+          transaction_position: integer(),
+          type: String.t()
+        }
+
+  defstruct [
+    :action,
+    :block_hash,
+    :block_number,
+    :gas_used,
+    :output,
+    :subtraces,
+    :trace_address,
+    :transaction_hash,
+    :transaction_position,
+    :type
+  ]
+
+  @doc ~S"""
+  Deserializes a single trace result from `trace_transction`. Note: a JSON-RPC response will
+  return an array of such traces.
+
+  ## Examples
+
+      iex> %{
+      ...>   "action" => %{
+      ...>     "callType" => "call",
+      ...>     "from" => "0x83806d539d4ea1c140489a06660319c9a303f874",
+      ...>     "gas" => "0x1a1f8",
+      ...>     "input" => "0x",
+      ...>     "to" => "0x1c39ba39e4735cb65978d4db400ddd70a72dc750",
+      ...>     "value" => "0x7a16c911b4d00000"
+      ...>   },
+      ...>   "blockHash" => "0x7eb25504e4c202cf3d62fd585d3e238f592c780cca82dacb2ed3cb5b38883add",
+      ...>   "blockNumber" => 3068185,
+      ...>   "result" => %{
+      ...>     "gasUsed" => "0x2982",
+      ...>     "output" => "0x"
+      ...>   },
+      ...>   "subtraces" => 2,
+      ...>   "traceAddress" => ["0x1c39ba39e4735cb65978d4db400ddd70a72dc750"],
+      ...>   "transactionHash" => "0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3",
+      ...>   "transactionPosition" => 2,
+      ...>   "type" => "call"
+      ...> }
+      ...> |> Signet.Trace.deserialize()
+      %Signet.Trace{
+        action: %Signet.Trace.Action{
+          call_type: "call",
+          from: Signet.Util.decode_hex!("0x83806d539d4ea1c140489a06660319c9a303f874"),
+          gas: 0x01a1f8,
+          input: <<>>,
+          to: Signet.Util.decode_hex!("0x1c39ba39e4735cb65978d4db400ddd70a72dc750"),
+          value: 0x7a16c911b4d00000,
+        },
+        block_hash: Signet.Util.decode_hex!("0x7eb25504e4c202cf3d62fd585d3e238f592c780cca82dacb2ed3cb5b38883add"),
+        block_number: 3068185,
+        gas_used: 0x2982,
+        output: <<>>,
+        subtraces: 2,
+        trace_address: [Signet.Util.decode_hex!("0x1c39ba39e4735cb65978d4db400ddd70a72dc750")],
+        transaction_hash: Signet.Util.decode_hex!("0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"),
+        transaction_position: 2,
+        type: "call"
+      }
+  """
+  @spec deserialize(map()) :: t() | no_return()
+  def deserialize(
+        params = %{
+          "blockNumber" => block_number,
+          "subtraces" => subtraces,
+          "transactionPosition" => transaction_position,
+          "type" => type
+        }
+      )
+      when is_integer(block_number) and is_integer(subtraces) and is_integer(transaction_position) and
+             is_binary(type) do
+    %__MODULE__{
+      action: Action.deserialize(params["action"]),
+      block_hash: Signet.Util.decode_word!(params["blockHash"]),
+      block_number: block_number,
+      gas_used: Signet.Util.decode_hex_number!(params["result"]["gasUsed"]),
+      output: Signet.Util.decode_hex!(params["result"]["output"]),
+      subtraces: subtraces,
+      trace_address: Enum.map(params["traceAddress"], &Signet.Util.decode_address!/1),
+      transaction_hash: Signet.Util.decode_word!(params["transactionHash"]),
+      transaction_position: transaction_position,
+      type: type
+    }
+  end
+
+  @doc ~S"""
+  Deserializes an array of trace results from `trace_transction`.
+
+  ## Examples
+
+      iex> [%{
+      ...>   "action" => %{
+      ...>     "callType" => "call",
+      ...>     "from" => "0x83806d539d4ea1c140489a06660319c9a303f874",
+      ...>     "gas" => "0x1a1f8",
+      ...>     "input" => "0x",
+      ...>     "to" => "0x1c39ba39e4735cb65978d4db400ddd70a72dc750",
+      ...>     "value" => "0x7a16c911b4d00000"
+      ...>   },
+      ...>   "blockHash" => "0x7eb25504e4c202cf3d62fd585d3e238f592c780cca82dacb2ed3cb5b38883add",
+      ...>   "blockNumber" => 3068185,
+      ...>   "result" => %{
+      ...>     "gasUsed" => "0x2982",
+      ...>     "output" => "0x"
+      ...>   },
+      ...>   "subtraces" => 2,
+      ...>   "traceAddress" => ["0x1c39ba39e4735cb65978d4db400ddd70a72dc750"],
+      ...>   "transactionHash" => "0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3",
+      ...>   "transactionPosition" => 2,
+      ...>   "type" => "call"
+      ...> }]
+      ...> |> Signet.Trace.deserialize_many()
+      [
+        %Signet.Trace{
+          action: %Signet.Trace.Action{
+            call_type: "call",
+            from: Signet.Util.decode_hex!("0x83806d539d4ea1c140489a06660319c9a303f874"),
+            gas: 0x01a1f8,
+            input: <<>>,
+            to: Signet.Util.decode_hex!("0x1c39ba39e4735cb65978d4db400ddd70a72dc750"),
+            value: 0x7a16c911b4d00000,
+          },
+          block_hash: Signet.Util.decode_hex!("0x7eb25504e4c202cf3d62fd585d3e238f592c780cca82dacb2ed3cb5b38883add"),
+          block_number: 3068185,
+          gas_used: 0x2982,
+          output: <<>>,
+          subtraces: 2,
+          trace_address: [Signet.Util.decode_hex!("0x1c39ba39e4735cb65978d4db400ddd70a72dc750")],
+          transaction_hash: Signet.Util.decode_hex!("0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"),
+          transaction_position: 2,
+          type: "call"
+        }
+      ]
+  """
+  @spec deserialize_many([map()]) :: [t()] | no_return()
+  def deserialize_many(traces), do: Enum.map(traces, &Signet.Trace.deserialize/1)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "0.2.0-alpha2",
+      version: "0.2.0-alpha3",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "0.2.0-alpha3",
+      version: "0.2.0-alpha4",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/client.ex
+++ b/test/support/client.ex
@@ -45,7 +45,11 @@ defmodule Signet.Test.Client do
     "0x4"
   end
 
-  def eth_getTransactionReceipt("0x0000000000000000000000000000000000000000000000000000000000000001"), do: %{}
+  def eth_getTransactionReceipt(
+        "0x0000000000000000000000000000000000000000000000000000000000000001"
+      ),
+      do: %{}
+
   def eth_getTransactionReceipt(_trx_id) do
     %{
       "blockHash" => "0xa957d47df264a31badc3ae823e10ac1d444b098d9b73d204c40426e57f47e8c3",
@@ -55,26 +59,75 @@ defmodule Signet.Test.Client do
       "effectiveGasPrice" => "0x5a9c688d4",
       "from" => "0x6221a9c005f6e47eb398fd867784cacfdcfff4e7",
       "gasUsed" => "0xb4c8",
-      "logs" => [%{
-        "logIndex" => "0x1",
-        "blockNumber" => "0x1b4",
-        "blockHash" => "0xaa8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcfdf829c5a142f1fccd7d",
-        "transactionHash" =>  "0xaadf829c5a142f1fccd7d8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcf",
-        "transactionIndex" => "0x0",
-        "address" => "0x16c5785ac562ff41e2dcfdf829c5a142f1fccd7d",
-        "data" => "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "topics" => [
-          "0x59ebeb90bc63057b6515673c3ecf9438e5058bca0f92585014eced636878c9a5"
-        ]
-      }],
+      "logs" => [
+        %{
+          "logIndex" => "0x1",
+          "blockNumber" => "0x1b4",
+          "blockHash" => "0xaa8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcfdf829c5a142f1fccd7d",
+          "transactionHash" =>
+            "0xaadf829c5a142f1fccd7d8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcf",
+          "transactionIndex" => "0x0",
+          "address" => "0x16c5785ac562ff41e2dcfdf829c5a142f1fccd7d",
+          "data" => "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "topics" => [
+            "0x59ebeb90bc63057b6515673c3ecf9438e5058bca0f92585014eced636878c9a5"
+          ]
+        }
+      ],
       "logsBloom" => "0x0000000000000000000000000000000000000000000000000000000000000001",
       "status" => "0x1",
       "to" => "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-      "transactionHash" =>
-        "0x85d995eba9763907fdf35cd2034144dd9d53ce32cbec21349d4b12823c6860c5",
+      "transactionHash" => "0x85d995eba9763907fdf35cd2034144dd9d53ce32cbec21349d4b12823c6860c5",
       "transactionIndex" => "0x66",
       "type" => "0x2"
     }
+  end
+
+  def trace_transaction(_trx_id) do
+    [
+      %{
+        "action" => %{
+          "callType" => "call",
+          "from" => "0x83806d539d4ea1c140489a06660319c9a303f874",
+          "gas" => "0x1a1f8",
+          "input" => "0x",
+          "to" => "0x1c39ba39e4735cb65978d4db400ddd70a72dc750",
+          "value" => "0x7a16c911b4d00000"
+        },
+        "blockHash" => "0x7eb25504e4c202cf3d62fd585d3e238f592c780cca82dacb2ed3cb5b38883add",
+        "blockNumber" => 3_068_185,
+        "result" => %{
+          "gasUsed" => "0x2982",
+          "output" => "0x"
+        },
+        "subtraces" => 2,
+        "traceAddress" => ["0x1c39ba39e4735cb65978d4db400ddd70a72dc750"],
+        "transactionHash" => "0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3",
+        "transactionPosition" => 2,
+        "type" => "call"
+      },
+      %{
+        "action" => %{
+          "callType" => "call",
+          "from" => "0x83806d539d4ea1c140489a06660319c9a303f874",
+          "gas" => "0x1a1f8",
+          "input" => "0x",
+          "to" => "0x1c39ba39e4735cb65978d4db400ddd70a72dc750",
+          "value" => "0x7a16c911b4d00000"
+        },
+        "blockHash" => "0x7eb25504e4c202cf3d62fd585d3e238f592c780cca82dacb2ed3cb5b38883add",
+        "blockNumber" => 3_068_186,
+        "result" => %{
+          "gasUsed" => "0x2982",
+          "output" => "0x"
+        },
+        "subtraces" => 2,
+        "traceAddress" => ["0x1c39ba39e4735cb65978d4db400ddd70a72dc750"],
+        "transactionHash" => "0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3",
+        "transactionPosition" => 2,
+        "type" => "call"
+      }
+    ]
   end
 
   def eth_gasPrice() do

--- a/test/trace_test.exs
+++ b/test/trace_test.exs
@@ -1,0 +1,5 @@
+defmodule Signet.TraceTest do
+  use ExUnit.Case, async: true
+  doctest Signet.Trace
+  doctest Signet.Trace.Action
+end


### PR DESCRIPTION
This patch adds basic support for the `trace_transaction` RPC call. See https://docs.infura.io/networks/ethereum/json-rpc-methods/trace-methods/trace_transaction for more information on the endpoint details.

Bump to 0.2.0-alpha3