### PR TITLE
Allow Setting Chain ID in Prepare Trx

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-alpha3"}
+    {:signet, "~> 1.0.0-alpha4"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-alpha3",
+      version: "1.0.0-alpha4",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch accepts `chain_id` as an input option to `prepare_trx` instead of using the default chain_id for the signer. This is as we move to a better version of multi-chain world.

Bump to 1.0.0-alpha4