### PR TITLE
Adjust RPC Call Return Value (1.0.0-alpha6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v1.0.0-alpha6
+
+- Adjust return value of RPC call [BREAKING]
+
+## v1.0.0-alpha5
+
+- Add `trace_call` Support (1.0.0-alpha5)
+
+## v1.0.0-alpha4
+
+- This patch accepts `chain_id` as an input option to `prepare_trx` instead of using the default chain_id for the signer. This is as we move to a better version of multi-chain world.
+
+## v1.0.0-alpha3
+
+- Bump ABI dep
+
+## v1.0.0-alpha2
+
+- Bump ABI dep
+
+## v1.0.0-alpha1
+
+- Support EIP-1559 transactions
+
 ## v0.1.10
 
 - Add simple auto-publish mechanism

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-alpha5"}
+    {:signet, "~> 1.0.0-alpha6"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-alpha5",
+      version: "1.0.0-alpha6",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Previously we had `send_rpc` return a tuple of the form `{:error, String.t()}`, which has problematic since in many cases that data was less useful than the error returned from the JSON-RPC node (e.g. the error code got put into that string). Here, we fix this by making this call always return `{:error, %{code: code, message: message}}`, which is easier for clients to parse. Additionally parsed information, such as `%{code: 3, message: "execution reverted", revert: <<1,2,3>>, error_abi: "Cool()", error_params: []}` can expand this struct, but it will always have code and message on it. This should be a boon for callers. Note: this is a breaking change and could break earlier clients.

Bump to 1.0.0-alpha6