### PR TITLE
Better RPC Decoding Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+
+## v1.0.0-alpha9
+
+- Improve error logging for RPC decoding errors
+
+## v1.0.0-alpha8
+
+- Add Fee History and MaxFeePerGas Endpoints [1.0.0-alpha8] (#34)
+  - Add Fee History Endpoint
+  - Try to simplify logic even more, don't apply buffer when values are set directly
+
+## v1.0.0-alpha7
+
+- Improve Trace Support [1.0.0-alpha7]
+
+- This patch improves trace support to handle more cases, such as contract creation and reverts. The trace code isn't heavily documented, so we're mostly going off of some real-life examples.
+
 ## v1.0.0-alpha6
 
 - Adjust return value of RPC call [BREAKING]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-alpha8"}
+    {:signet, "~> 1.0.0-alpha9"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-alpha8",
+      version: "1.0.0-alpha9",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch improves RPC decoding messages by adding logs and the ability to get back verbose error messages. This is the first of probably a few PRs to make it easier to understand when things go wrong.