### PR TITLE
Add a few extra network chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-beta1"}
+    {:signet, "~> 1.0.0-beta2"}
   ]
 end
 ```

--- a/lib/signet/typed.ex
+++ b/lib/signet/typed.ex
@@ -16,7 +16,13 @@ defmodule Signet.Typed do
   defmodule Type do
     defstruct [:fields]
 
-    @type primitive() :: :address | {:uint, number()} | {:bytes, number()} | :string | :bytes | {:array, primitive()}
+    @type primitive() ::
+            :address
+            | {:uint, number()}
+            | {:bytes, number()}
+            | :string
+            | :bytes
+            | {:array, primitive()}
     @type field_type() :: primitive() | String.t()
     @type type_list() :: [{String.t(), field_type()}]
     @type t() :: %__MODULE__{fields: type_list()}
@@ -145,6 +151,7 @@ defmodule Signet.Typed do
     def deserialize_type("bytes32"), do: {:bytes, 32}
     def deserialize_type("string"), do: :string
     def deserialize_type("bytes"), do: :bytes
+
     def deserialize_type(ty) when is_binary(ty) do
       cond do
         String.ends_with?(ty, "[]") ->
@@ -193,8 +200,8 @@ defmodule Signet.Typed do
     def deserialize_value!(value, {:bytes, sz}),
       do: Signet.Util.pad(Signet.Util.decode_hex!(value), sz)
 
-    def deserialize_value!(value, {:array, ty}) when is_list(value), do:
-      Enum.map(value, &deserialize_value!(&1, ty))
+    def deserialize_value!(value, {:array, ty}) when is_list(value),
+      do: Enum.map(value, &deserialize_value!(&1, ty))
 
     @doc ~S"""
     Serializes a value of a given type to pass to JSON or JavaScript.
@@ -234,8 +241,8 @@ defmodule Signet.Typed do
       |> Signet.Util.encode_hex()
     end
 
-    def serialize_value(value, {:array, ty}) when is_list(value), do:
-      Enum.map(value, &serialize_value(&1, ty))
+    def serialize_value(value, {:array, ty}) when is_list(value),
+      do: Enum.map(value, &serialize_value(&1, ty))
 
     @doc ~S"""
     Encodes a value for `encodeData`, as per the EIP-712 spec. Specifically, raw values are
@@ -267,6 +274,7 @@ defmodule Signet.Typed do
     def encode_data_value(value, :string), do: Signet.Util.keccak(value)
     def encode_data_value(value, :bytes), do: Signet.Util.keccak(value)
     def encode_data_value(value, {:bytes, _}), do: Signet.Util.pad(value, 32)
+
     def encode_data_value(value, {:array, ty}) do
       value
       |> Enum.map(&encode_data_value(&1, ty))

--- a/lib/signet/util.ex
+++ b/lib/signet/util.ex
@@ -255,7 +255,12 @@ defmodule Signet.Util do
     ropsten: 2,
     rinkeby: 4,
     goerli: 5,
-    kovan: 42
+    kovan: 42,
+    base: 8453,
+    base_sepolia: 84532,
+    arbitrum: 42161,
+    mumbai: 80001,
+    sepolia: 11_155_111
   }
 
   @doc ~S"""
@@ -268,6 +273,9 @@ defmodule Signet.Util do
 
       iex> Signet.Util.parse_chain_id(:goerli)
       5
+
+      iex> Signet.Util.parse_chain_id(:sepolia)
+      11155111
   """
   def parse_chain_id(chain_id) when is_atom(chain_id), do: Map.fetch!(@chains, chain_id)
   def parse_chain_id(chain_id) when is_integer(chain_id), do: chain_id

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-beta1",
+      version: "1.0.0-beta2",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch adds a few extra network chains, e.g. `sepolia` and `base_sepolia`.

Also we run `mix format`.

Bump to 1.0.0-beta2