### PR TITLE
Accept `id` to `send_rpc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-beta3"}
+    {:signet, "~> 1.0.0-beta4"}
   ]
 end
 ```

--- a/lib/signet/rpc.ex
+++ b/lib/signet/rpc.ex
@@ -21,9 +21,8 @@ defmodule Signet.RPC do
     ] ++ extra_headers
   end
 
-  defp get_body(method, params) do
-    id = System.unique_integer([:positive])
-
+  @doc false
+  def get_body(method, params, id) do
     %{
       "jsonrpc" => "2.0",
       "method" => method,
@@ -145,7 +144,8 @@ defmodule Signet.RPC do
     timeout = Keyword.get(opts, :timeout, 30_000)
     verbose = Keyword.get(opts, :verbose, false)
     url = Keyword.get(opts, :ethereum_node, ethereum_node())
-    body = get_body(method, params)
+    id = Keyword.get_lazy(opts, :id, fn -> System.unique_integer([:positive]) end)
+    body = get_body(method, params, id)
 
     case http_client().post(url, Jason.encode!(body), headers(headers), recv_timeout: timeout) do
       {:ok, %HTTPoison.Response{status_code: code, body: resp_body}} when code in 200..299 ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-beta3",
+      version: "1.0.0-beta4",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch simply allows the caller to specify the id to the `send_rpc` call.

Bump to 1.0.0-beta4