### PR TITLE
zImprove RPC Error Handling 1.0.0-beta7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## v1.0.0-beta7
+
+- Improve error handling of RPC calls
+
 ## v1.0.0-beta6
 
 - Add `eth_getCode` support

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-beta6"}
+    {:signet, "~> 1.0.0-beta7"}
   ]
 end
 ```

--- a/lib/signet/rpc.ex
+++ b/lib/signet/rpc.ex
@@ -32,7 +32,7 @@ defmodule Signet.RPC do
   end
 
   # See https://blog.soliditylang.org/2021/04/21/custom-errors/
-  defp decode_error(<<error_hash::binary-size(4), error_data::binary>>, errors) do
+  defp decode_error(<<error_hash::binary-size(4), error_data::binary>>, errors) when is_list(errors) do
     all_errors = ["Panic(uint256)" | errors]
 
     case Enum.find(all_errors, fn error ->
@@ -308,6 +308,10 @@ defmodule Signet.RPC do
       iex> Signet.Transaction.V2.new(1, {1, :gwei}, {100, :gwei}, 100_000, <<1::160>>, {2, :wei}, <<1, 2, 3>>, [<<2::160>>, <<3::160>>], :goerli)
       iex> |> Signet.RPC.estimate_gas()
       {:ok, 0xdd}
+
+      iex> Signet.Transaction.V2.new(1, {1, :gwei}, {100, :gwei}, 100_000, <<10::160>>, {2, :wei}, <<1, 2, 3>>, [<<2::160>>, <<3::160>>], :goerli)
+      iex> |> Signet.RPC.estimate_gas()
+      {:error, %{code: 3, message: "execution reverted: Dai/insufficient-balance", revert: Signet.Util.decode_hex!("0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000184461692f696e73756666696369656e742d62616c616e63650000000000000000")}}
   """
   def estimate_gas(trx, opts \\ []) do
     from = Keyword.get(opts, :from)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-beta6",
+      version: "1.0.0-beta7",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/client.ex
+++ b/test/support/client.ex
@@ -806,6 +806,17 @@ defmodule Signet.Test.Client do
     "0xcc"
   end
 
+  # Reverting
+  def eth_estimateGas(_trx = %{"to" => "0x000000000000000000000000000000000000000A"}, _block) do
+    {:error,
+     %{
+       "code" => 3,
+       "message" => "execution reverted: Dai/insufficient-balance",
+       "data" =>
+         "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000184461692f696e73756666696369656e742d62616c616e63650000000000000000"
+     }}
+  end
+
   # V1
   def eth_estimateGas(_trx = %{"gasPrice" => _}, _block) do
     "0x0d"


### PR DESCRIPTION
This patch fixes a bug where RPC calls would crash if they received errors from the remote node.