### PR TITLE
Add Escape to Macro Expands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0-charlie2
+
+- Escape macro expands
+
 ## v1.0.0-charlie1
 
 - Add Sleuth support

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-charlie1"}
+    {:signet, "~> 1.0.0-charlie2"}
   ]
 end
 ```

--- a/lib/mix/signet.gen.ex
+++ b/lib/mix/signet.gen.ex
@@ -490,14 +490,14 @@ defmodule Mix.Tasks.Signet.Gen do
       selector_fn =
         quote do
           def unquote(selector_fun_name)() do
-            unquote(selector)
+            unquote(Macro.escape(selector))
           end
         end
 
       event_selector_fn =
         quote do
           def unquote(event_selector_fun_name)() do
-            unquote(event_selector)
+            unquote(Macro.escape(event_selector))
           end
         end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-charlie1",
+      version: "1.0.0-charlie2",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Previously we weren't escaping the function selector, that led to concerns with certain expansions. Here we properly escape.

See https://hexdocs.pm/elixir/Macro.html#escape/1

Bump to 1.0.0-charlie2