### PR TITLE
Fix Call Params

### DIFF
--- a/lib/signet/rpc.ex
+++ b/lib/signet/rpc.ex
@@ -1234,7 +1234,8 @@ defmodule Signet.RPC do
     end
   end
 
-  defp to_call_params(trx = %Signet.Transaction.V1{}, from) do
+  @doc false
+  def to_call_params(trx = %Signet.Transaction.V1{}, from) do
     %{
       from: nil_map(from, &Hex.encode_big_hex/1),
       to: nil_map(trx.to, &Hex.encode_big_hex/1),
@@ -1244,14 +1245,14 @@ defmodule Signet.RPC do
     }
   end
 
-  defp to_call_params(trx = %Signet.Transaction.V2{}, from) do
+  def to_call_params(trx = %Signet.Transaction.V2{}, from) do
     %{
       from: nil_map(from, &Hex.encode_big_hex/1),
       to: nil_map(trx.destination, &Hex.encode_big_hex/1),
       maxPriorityFeePerGas: nil_map(trx.max_priority_fee_per_gas, &Hex.encode_short_hex/1),
       maxFeePerGas: nil_map(trx.max_fee_per_gas, &Hex.encode_short_hex/1),
       value: nil_map(trx.amount, &Hex.encode_short_hex/1),
-      data: nil_map(trx.data, &Hex.encode_short_hex/1)
+      data: nil_map(trx.data, &Hex.encode_big_hex/1)
     }
   end
 


### PR DESCRIPTION
This patch fixes call params. For reasons that I don't understand, sometimes we need to use short hex (e.g `0x5` to represent 0x05), but apparently for the `data` parameter, you need to pass in byte-aligned hex. So we fix that since we were getting errors from Anvil (maybe Anvil is weird here?).

Also, we make `to_call_params/2` public since other functions can use it, but we currently don't document it specifically.