### PR TITLE
Add Sleuth Annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.0.0-charlie5
+
+- [Fix Call Params](https://github.com/hayesgm/signet/pull/52)
+- [Add Sleuth Annotations](https://github.com/hayesgm/signet/pull/54)
+
 ## v1.0.0-charlie4
 
 - Bump ABI dependency

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-charlie4"}
+    {:signet, "~> 1.0.0-charlie5"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-charlie4",
+      version: "1.0.0-charlie5",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/sleuth_test.exs
+++ b/test/sleuth_test.exs
@@ -35,9 +35,27 @@ defmodule SleuthTest do
                )
     end
 
+    test "queryTwo() - annotated" do
+      assert {:ok, %{"x" => {{:uint, 256}, 2}, "y" => {{:uint, 256}, 3}}} ==
+               Signet.Sleuth.query_annotated(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_two(),
+                 Signet.Contract.BlockNumber.query_two_selector()
+               )
+    end
+
     test "queryThree()" do
       assert {:ok, 2} ==
                Signet.Sleuth.query(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_three(),
+                 Signet.Contract.BlockNumber.query_three_selector()
+               )
+    end
+
+    test "queryThree() - annotated" do
+      assert {:ok, {{:uint, 256}, 2}} ==
+               Signet.Sleuth.query_annotated(
                  Signet.Contract.BlockNumber.bytecode(),
                  Signet.Contract.BlockNumber.encode_query_three(),
                  Signet.Contract.BlockNumber.query_three_selector()
@@ -54,6 +72,22 @@ defmodule SleuthTest do
                 }
               }} ==
                Signet.Sleuth.query(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_cool(),
+                 Signet.Contract.BlockNumber.query_cool_selector()
+               )
+    end
+
+    test "queryCool() - annotated" do
+      assert {:ok,
+              %{
+                "cool" => %{
+                  "fun" => %{"cat" => {:string, "meow"}},
+                  "x" => {:string, "hi"},
+                  "ys" => [{{:uint, 256}, 1}, {{:uint, 256}, 2}, {{:uint, 256}, 3}]
+                }
+              }} ==
+               Signet.Sleuth.query_annotated(
                  Signet.Contract.BlockNumber.bytecode(),
                  Signet.Contract.BlockNumber.encode_query_cool(),
                  Signet.Contract.BlockNumber.query_cool_selector()


### PR DESCRIPTION
This patch adds annotations to Sleuth, which includes the types of values so the downstream service can encode certain values how it pleases.

Bump to 1.0.0-charlie5