### PR TITLE
Partial EIP-712 Domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0-charlie6
+
+- [Partial EIP-712 Domains](https://github.com/hayesgm/signet/pull/55)
+
 ## v1.0.0-charlie5
 
 - [Fix Call Params](https://github.com/hayesgm/signet/pull/52)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-charlie5"}
+    {:signet, "~> 1.0.0-charlie6"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-charlie5",
+      version: "1.0.0-charlie6",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/typed_test.exs
+++ b/test/typed_test.exs
@@ -1,5 +1,6 @@
 defmodule Signet.TypedTest do
   use ExUnit.Case, async: true
+  use Signet.Hex
   doctest Signet.Typed
   doctest Signet.Typed.Domain
   doctest Signet.Typed.Type


### PR DESCRIPTION
The EIP-712 spec allows for EIP-712 domains which include a _subset_ of the expected keys (`chainId`, `name`, `version`, `verifyingContract` and `salt`). This patch patches our Signet code s.t. we properly allow for domain sub-sets.

Bump to 1.0.0-charlie6