### PR TITLE
Bump ABI for Event Decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0-charlie7
+
+- [Improve ABI Event Decoding](https://github.com/hayesgm/signet/pull/56)
+
 ## v1.0.0-charlie6
 
 - [Partial EIP-712 Domains](https://github.com/hayesgm/signet/pull/55)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-charlie6"}
+    {:signet, "~> 1.0.0-charlie7"}
   ]
 end
 ```

--- a/lib/mix/signet.gen.ex
+++ b/lib/mix/signet.gen.ex
@@ -233,10 +233,7 @@ defmodule Mix.Tasks.Signet.Gen do
     decode_error_fun_name = String.to_atom("decode_#{Macro.underscore(fn_name)}_error")
     decode_call_fun_name = String.to_atom("decode_#{Macro.underscore(fn_name)}_call")
 
-    event_selector = %{
-      selector
-      | types: [%{name: "_topic", type: {:uint, 256}, indexed: true} | selector.types]
-    }
+    event_selector = selector
 
     argument_types =
       case selector.function_type do
@@ -541,21 +538,21 @@ defmodule Mix.Tasks.Signet.Gen do
       generic_decode_call_fn =
         quote do
           def decode_call(calldata = <<unquote_splicing(abi_enc_signature_list)>> <> _) do
-            {:ok, {unquote(error_name), unquote(decode_call_fun_name)(calldata)}}
+            {:ok, unquote(error_name), unquote(decode_call_fun_name)(calldata)}
           end
         end
 
       generic_error_fn =
         quote do
           def decode_error(error = <<unquote_splicing(abi_enc_signature_list)>> <> _) do
-            {:ok, {unquote(error_name), unquote(decode_error_fun_name)(error)}}
+            {:ok, unquote(error_name), unquote(decode_error_fun_name)(error)}
           end
         end
 
       generic_event_fn =
         quote do
           def decode_event(topics = [<<unquote_splicing(signature_list)>> | _], data) do
-            {:ok, unquote(decode_event_fun_name)(topics, data)}
+            unquote(decode_event_fun_name)(topics, data)
           end
         end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-charlie6",
+      version: "1.0.0-charlie7",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -52,7 +52,7 @@ defmodule Signet.MixProject do
       {:curvy, "~> 0.3.1"},
       {:goth, "~> 1.4.3", optional: true},
       {:ex_rlp, "~> 0.6.0"},
-      {:abi, "~> 1.0.0-alpha7"},
+      {:abi, "~> 1.0.0-alpha8"},
       {:junit_formatter, "~> 3.3.1", only: [:test]}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "abi": {:hex, :abi, "1.0.0-alpha7", "6c16548f0be33dfb1d008e1b6c6b211146e08d01f24cf20a4584e5405b18664f", [:mix], [{:ex_sha3, "~> 0.1.4", [hex: :ex_sha3, repo: "hexpm", optional: false]}, {:jason, "~> 1.4", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "d5b4b64fe7c22af237d0fd4afa2d02973d166951d55cf9e3a6fa11fa67bdd4ba"},
+  "abi": {:hex, :abi, "1.0.0-alpha8", "7344927b9b52a2e9b8160a6bd9a38b2dc8c41b53425c651076798114c805f76a", [:mix], [{:ex_sha3, "~> 0.1.4", [hex: :ex_sha3, repo: "hexpm", optional: false]}, {:jason, "~> 1.4", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "38e6a8d207ee01a61b8c1a1408b5c44ed2ab35e22f1c25111dee9e28ac508851"},
   "castore": {:hex, :castore, "1.0.5", "9eeebb394cc9a0f3ae56b813459f990abb0a3dedee1be6b27fdb50301930502f", [:mix], [], "hexpm", "8d7c597c3e4a64c395980882d4bca3cebb8d74197c590dc272cfd3b6a6310578"},
   "certifi": {:hex, :certifi, "2.12.0", "2d1cca2ec95f59643862af91f001478c9863c2ac9cb6e2f89780bfd8de987329", [:rebar3], [], "hexpm", "ee68d85df22e554040cdb4be100f33873ac6051387baf6a8f6ce82272340ff1c"},
   "curvy": {:hex, :curvy, "0.3.1", "2645a11452743a37de2393da4d2e60700632498b166413b4f73bc34c57a911e1", [:mix], [], "hexpm", "82df293452f7b751becabc29e8aad0f7d88ffdcd790ac7a2ea16ea1544681d8a"},

--- a/test/ierc20_test.exs
+++ b/test/ierc20_test.exs
@@ -9,10 +9,32 @@ defmodule Signet.Contract.IERC20Test do
   ```
   """
   use ExUnit.Case, async: true
+  use Signet.Hex
   doctest Signet.Contract.IERC20
   alias Signet.Contract.IERC20
 
   test "returns correct contract name" do
     assert IERC20.contract_name() == "IERC20"
+  end
+
+  test "correctly decodes event" do
+    assert IERC20.decode_event(
+             [
+               ~h[0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef],
+               ~h[0x000000000000000000000000b2b7c1795f19fbc28fda77a95e59edbb8b3709c8],
+               ~h[0x0000000000000000000000007795126b3ae468f44c901287de98594198ce38ea]
+             ],
+             ~h[0x00000000000000000000000000000000000000000000000000000004a817c800]
+           ) ==
+             {:ok, "Transfer",
+              %{
+                "value" => 20_000_000_000,
+                "from" => ~h[0xb2b7c1795f19fbc28fda77a95e59edbb8b3709c8],
+                "to" => ~h[0x7795126b3ae468f44c901287de98594198ce38ea]
+              }}
+  end
+
+  test "correctly decodes call" do
+    assert IERC20.decode_call(~h[0x313CE567]) == {:ok, "decimals", []}
   end
 end

--- a/test/support/signet/contract/block_number.ex
+++ b/test/support/signet/contract/block_number.ex
@@ -178,19 +178,19 @@ defmodule Signet.Contract.BlockNumber do
   end
 
   def decode_call(calldata = <<44, 70, 178, 5>> <> _) do
-    {:ok, {"query", decode_query_call(calldata)}}
+    {:ok, "query", decode_query_call(calldata)}
   end
 
   def decode_call(calldata = <<107, 188, 156, 20>> <> _) do
-    {:ok, {"queryCool", decode_query_cool_call(calldata)}}
+    {:ok, "queryCool", decode_query_cool_call(calldata)}
   end
 
   def decode_call(calldata = <<219, 127, 37, 93>> <> _) do
-    {:ok, {"queryThree", decode_query_three_call(calldata)}}
+    {:ok, "queryThree", decode_query_three_call(calldata)}
   end
 
   def decode_call(calldata = <<53, 0, 122, 122>> <> _) do
-    {:ok, {"queryTwo", decode_query_two_call(calldata)}}
+    {:ok, "queryTwo", decode_query_two_call(calldata)}
   end
 
   def decode_call(_) do

--- a/test/support/signet/contract/ierc20.ex
+++ b/test/support/signet/contract/ierc20.ex
@@ -373,10 +373,9 @@ defmodule Signet.Contract.IERC20 do
       returns: nil,
       state_mutability: nil,
       types: [
-        %{indexed: true, name: "_topic", type: {:uint, 256}},
-        %{name: "owner", type: :address},
-        %{name: "spender", type: :address},
-        %{name: "value", type: {:uint, 256}}
+        %{indexed: true, name: "owner", type: :address},
+        %{indexed: true, name: "spender", type: :address},
+        %{indexed: false, name: "value", type: {:uint, 256}}
       ]
     }
   end
@@ -397,10 +396,9 @@ defmodule Signet.Contract.IERC20 do
       returns: nil,
       state_mutability: nil,
       types: [
-        %{indexed: true, name: "_topic", type: {:uint, 256}},
-        %{name: "from", type: :address},
-        %{name: "to", type: :address},
-        %{name: "value", type: {:uint, 256}}
+        %{indexed: true, name: "from", type: :address},
+        %{indexed: true, name: "to", type: :address},
+        %{indexed: false, name: "value", type: {:uint, 256}}
       ]
     }
   end
@@ -414,39 +412,39 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_call(calldata = <<221, 98, 237, 62>> <> _) do
-    {:ok, {"allowance", decode_allowance_call(calldata)}}
+    {:ok, "allowance", decode_allowance_call(calldata)}
   end
 
   def decode_call(calldata = <<9, 94, 167, 179>> <> _) do
-    {:ok, {"approve", decode_approve_call(calldata)}}
+    {:ok, "approve", decode_approve_call(calldata)}
   end
 
   def decode_call(calldata = <<112, 160, 130, 49>> <> _) do
-    {:ok, {"balanceOf", decode_balance_of_call(calldata)}}
+    {:ok, "balanceOf", decode_balance_of_call(calldata)}
   end
 
   def decode_call(calldata = <<49, 60, 229, 103>> <> _) do
-    {:ok, {"decimals", decode_decimals_call(calldata)}}
+    {:ok, "decimals", decode_decimals_call(calldata)}
   end
 
   def decode_call(calldata = <<6, 253, 222, 3>> <> _) do
-    {:ok, {"name", decode_name_call(calldata)}}
+    {:ok, "name", decode_name_call(calldata)}
   end
 
   def decode_call(calldata = <<149, 216, 155, 65>> <> _) do
-    {:ok, {"symbol", decode_symbol_call(calldata)}}
+    {:ok, "symbol", decode_symbol_call(calldata)}
   end
 
   def decode_call(calldata = <<24, 22, 13, 221>> <> _) do
-    {:ok, {"totalSupply", decode_total_supply_call(calldata)}}
+    {:ok, "totalSupply", decode_total_supply_call(calldata)}
   end
 
   def decode_call(calldata = <<169, 5, 156, 187>> <> _) do
-    {:ok, {"transfer", decode_transfer_call(calldata)}}
+    {:ok, "transfer", decode_transfer_call(calldata)}
   end
 
   def decode_call(calldata = <<35, 184, 114, 221>> <> _) do
-    {:ok, {"transferFrom", decode_transfer_from_call(calldata)}}
+    {:ok, "transferFrom", decode_transfer_from_call(calldata)}
   end
 
   def decode_call(_) do
@@ -461,7 +459,7 @@ defmodule Signet.Contract.IERC20 do
         ],
         data
       ) do
-    {:ok, decode_approval_event(topics, data)}
+    decode_approval_event(topics, data)
   end
 
   def decode_event(
@@ -472,7 +470,7 @@ defmodule Signet.Contract.IERC20 do
         ],
         data
       ) do
-    {:ok, decode_transfer_ddf252ad_event(topics, data)}
+    decode_transfer_ddf252ad_event(topics, data)
   end
 
   def decode_event(_) do


### PR DESCRIPTION
This patch improves Event Decoders to return error tuples and more reasonably handle the event signature (topic0). This creates a small breaking change in Signet, but nothing too serious. E.g. `Contract.IErc20.decode_transfer_ddf252ad_event` now returns a tuple instead of a raw decode. This is a reasonable and good change.

Bump to 1.0.0-charlie7