### PR TITLE
Add OpenChain API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0-delta1
+
+- [Add OpenChain API](https://github.com/hayesgm/signet/pull/59)
+
 ## v1.0.0-charlie9
 
 - [Bump ABI Version](https://github.com/hayesgm/signet/pull/58)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-charlie9"}
+    {:signet, "~> 1.0.0-delta1"}
   ]
 end
 ```

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,5 +2,6 @@ import Config
 
 config :tesla, adapter: Tesla.Mock
 config :signet, :client, Signet.Test.Client
+config :signet, :open_chain_client, Signet.OpenChainTest.TestClient
 config :signet, :chain_id, :goerli
 config :signet, :signer, default: {:priv_key, <<1::256>>}

--- a/lib/signet/open_chain.ex
+++ b/lib/signet/open_chain.ex
@@ -1,0 +1,187 @@
+defmodule Signet.OpenChain do
+  @moduledoc ~S"""
+  API Client for [OpenChain.xyz](https://openchain.xyz] API.
+  """
+
+  use Signet.Hex
+
+  defmodule Signatures do
+    defstruct [:events, :functions]
+
+    @type t :: %__MODULE__{
+            events: [{binary(), String.t()}],
+            functions: [{binary(), String.t()}]
+          }
+
+    @doc ~S"""
+    Deserializes an open chain signature.
+
+    ## Examples
+
+        iex> %{
+        ...>   "event" => %{
+        ...>     "0x08c379a0" => []
+        ...>   },
+        ...>   "function" => %{
+        ...>     "0x08c379a0" => [
+        ...>       %{
+        ...>         "name" => "Error(string)",
+        ...>         "filtered" => false
+        ...>       }
+        ...>     ]
+        ...>   }
+        ...> }
+        ...> |> Signet.OpenChain.Signatures.deserialize()
+        %Signet.OpenChain.Signatures{
+          events: [],
+          functions: [
+            {<<8, 195, 121, 160>>, "Error(string)"}
+          ]
+        }
+    """
+    def deserialize(%{"event" => event_list, "function" => function_list}) do
+      %__MODULE__{
+        events: decode_entries(event_list),
+        functions: decode_entries(function_list)
+      }
+    end
+
+    defp decode_entries(entries) when is_map(entries) do
+      entries
+      |> Enum.into([])
+      |> Enum.map(fn {k, vs} ->
+        vs
+        |> Enum.filter(fn v -> not v["filtered"] end)
+        |> Enum.map(fn v -> {from_hex!(k), v["name"]} end)
+      end)
+      |> List.flatten()
+    end
+  end
+
+  defmodule API do
+    def http_client(), do: Application.get_env(:signet, :open_chain_client, HTTPoison)
+
+    @spec get(String.t(), Keyword.t()) :: {:ok, term()} | {:error, String.t()}
+    def get(url, opts) do
+      headers = Keyword.get(opts, :headers, [])
+      timeout = Keyword.get(opts, :timeout, 30_000)
+
+      case http_client().get(url, headers, recv_timeout: timeout) do
+        {:ok, %HTTPoison.Response{status_code: code, body: resp_body}} when code in 200..299 ->
+          case Jason.decode(resp_body) do
+            {:ok, resp} ->
+              case resp do
+                %{"ok" => true, "result" => result} ->
+                  {:ok, result}
+
+                %{"ok" => false, "error" => error} ->
+                  {:error, error}
+              end
+
+            {:error, json_error} ->
+              {:error, Jason.DecodeError.message(json_error)}
+          end
+
+        {:error, %HTTPoison.Error{reason: reason}} ->
+          {:error, "error: #{inspect(reason)}"}
+      end
+    end
+
+    @doc ~S"""
+    Runs a lookup query from OpenChain, returning matching signtures.
+
+    ## Examples
+
+        iex> Signet.OpenChain.API.lookup([<<8, 195, 121, 160>>], [])
+        {:ok,
+          %Signet.OpenChain.Signatures{
+            events: [],
+            functions: [{<<8, 195, 121, 160>>, "Error(string)"}]
+          }
+        }
+    """
+    @spec lookup([binary()], [binary()], Keyword.t()) ::
+            {:ok, Signatures.t()} | {:error, String.t()}
+    def lookup(event_signatures, function_signatures, opts \\ []) do
+      {filter, opts} = Keyword.pop(opts, :filter, true)
+
+      events =
+        event_signatures
+        |> Enum.map(&Signet.Hex.to_hex/1)
+        |> Enum.join(",")
+
+      functions =
+        function_signatures
+        |> Enum.map(&Signet.Hex.to_hex/1)
+        |> Enum.join(",")
+
+      with {:ok, resp} <-
+             get(
+               "signature-database/v1/lookup?#{URI.encode_query(events: events, functions: functions, filter: filter)}",
+               opts
+             ) do
+        {:ok, Signatures.deserialize(resp)}
+      end
+    end
+  end
+
+  @doc ~S"""
+  Tries to lookup given signature of given type.
+
+  ## Examples
+
+      iex> Signet.OpenChain.lookup(<<8, 195, 121, 160>>, :function)
+      {:ok, "Error(string)"}
+  """
+  def lookup(signature, type, opts \\ []) do
+    {raise_on_multiple, opts} = Keyword.pop(opts, :raise_on_multiple, false)
+
+    found_signatures_result =
+      case type do
+        :function ->
+          with {:ok, signatures} <- API.lookup([], [signature], opts) do
+            {:ok, signatures.functions}
+          end
+
+        :event ->
+          with {:ok, signatures} <- API.lookup([signature], [], opts) do
+            {:ok, signatures.events}
+          end
+      end
+
+    with {:ok, found_signatures} <- found_signatures_result do
+      case Enum.count(found_signatures) do
+        0 ->
+          {:error, "Signature not found"}
+
+        x when x == 1 or not raise_on_multiple ->
+          {^signature, abi} = List.first(found_signatures)
+
+          {:ok, abi}
+
+        _ ->
+          {:error, "Multiple matching signatures: #{Enum.join(found_signatures, ",")}"}
+      end
+    end
+  end
+
+  @doc ~S"""
+  Looks up and tries to decode a given error message from its ABI-encoded form.
+
+  ## Examples
+
+      iex> Signet.OpenChain.lookup_error(~h[0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001b43616c6c6572206e6f74206174746573746572206d616e616765720000000000])
+      {:ok, ["Caller not attester manager"]}
+  """
+  def lookup_error(_, opts \\ [])
+
+  def lookup_error(<<signature::binary-size(4), data::binary>>, opts) do
+    with {:ok, signature} <- lookup(signature, :function, opts),
+         function_selector <- ABI.FunctionSelector.decode(signature),
+         result <- ABI.decode(function_selector, data) do
+      {:ok, result}
+    end
+  end
+
+  def lookup_error(_, _opts), do: {:error, "Error must include 4-byte signature"}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-charlie9",
+      version: "1.0.0-delta1",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/open_chain_test.exs
+++ b/test/open_chain_test.exs
@@ -1,0 +1,33 @@
+defmodule Signet.OpenChainTest do
+  use ExUnit.Case, async: true
+  use Signet.Hex
+  doctest Signet.OpenChain
+  doctest Signet.OpenChain.Signatures
+  doctest Signet.OpenChain.API
+
+
+  defmodule TestClient do
+    @lookup_success ~S"""
+    {
+      "ok": true,
+      "result": {
+        "event": {
+          "0x08c379a0": []
+        },
+        "function": {
+          "0x08c379a0": [
+            {
+              "name": "Error(string)",
+              "filtered": false
+            }
+          ]
+        }
+      }
+    }
+    """
+
+    def get("signature-database/v1/lookup?" <> _params, _headers, _opts) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: @lookup_success}}
+    end
+  end
+end


### PR DESCRIPTION
This patch begins to add the [OpenChain API](https://docs.openchain.xyz) which allows us to decode errors from a remote database. This should give us extra benefits when trying to decode unknown errors. We can later integrate this OpenChain API into more Signet systems.