### PR TITLE
Add OpenChain Base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0-delta2
+
+- [Add OpenChain Base URL](https://github.com/hayesgm/signet/pull/60)
+
 ## v1.0.0-delta1
 
 - [Add OpenChain API](https://github.com/hayesgm/signet/pull/59)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-delta1"}
+    {:signet, "~> 1.0.0-delta2"}
   ]
 end
 ```

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,5 +3,6 @@ import Config
 config :tesla, adapter: Tesla.Mock
 config :signet, :client, Signet.Test.Client
 config :signet, :open_chain_client, Signet.OpenChainTest.TestClient
+config :signet, :open_chain_base_url, "https://example.com/open-chain"
 config :signet, :chain_id, :goerli
 config :signet, :signer, default: {:priv_key, <<1::256>>}

--- a/lib/signet/open_chain.ex
+++ b/lib/signet/open_chain.ex
@@ -61,6 +61,8 @@ defmodule Signet.OpenChain do
   defmodule API do
     def http_client(), do: Application.get_env(:signet, :open_chain_client, HTTPoison)
 
+    @base_url Application.compile_env(:signet, :open_chain_base_url, "https://api.openchain.xyz")
+
     @spec get(String.t(), Keyword.t()) :: {:ok, term()} | {:error, String.t()}
     def get(url, opts) do
       headers = Keyword.get(opts, :headers, [])
@@ -117,7 +119,7 @@ defmodule Signet.OpenChain do
 
       with {:ok, resp} <-
              get(
-               "signature-database/v1/lookup?#{URI.encode_query(events: events, functions: functions, filter: filter)}",
+               "#{@base_url}/signature-database/v1/lookup?#{URI.encode_query(events: events, functions: functions, filter: filter)}",
                opts
              ) do
         {:ok, Signatures.deserialize(resp)}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-delta1",
+      version: "1.0.0-delta2",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/open_chain_test.exs
+++ b/test/open_chain_test.exs
@@ -26,7 +26,7 @@ defmodule Signet.OpenChainTest do
     }
     """
 
-    def get("signature-database/v1/lookup?" <> _params, _headers, _opts) do
+    def get("https://example.com/open-chain/signature-database/v1/lookup?" <> _params, _headers, _opts) do
       {:ok, %HTTPoison.Response{status_code: 200, body: @lookup_success}}
     end
   end


### PR DESCRIPTION
This patch adds a configurable base URL for OpenChain API.

Bump to delta2