### PR TITLE
Fix OpenChain API Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0-delta3
+
+- [Fix OpenChain API Params](https://github.com/hayesgm/signet/pull/61)
+
 ## v1.0.0-delta2
 
 - [Add OpenChain Base URL](https://github.com/hayesgm/signet/pull/60)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-delta2"}
+    {:signet, "~> 1.0.0-delta3"}
   ]
 end
 ```

--- a/lib/signet/open_chain.ex
+++ b/lib/signet/open_chain.ex
@@ -119,7 +119,7 @@ defmodule Signet.OpenChain do
 
       with {:ok, resp} <-
              get(
-               "#{@base_url}/signature-database/v1/lookup?#{URI.encode_query(events: events, functions: functions, filter: filter)}",
+               "#{@base_url}/signature-database/v1/lookup?#{URI.encode_query(event: events, function: functions, filter: filter)}",
                opts
              ) do
         {:ok, Signatures.deserialize(resp)}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-delta2",
+      version: "1.0.0-delta3",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/open_chain_test.exs
+++ b/test/open_chain_test.exs
@@ -5,7 +5,6 @@ defmodule Signet.OpenChainTest do
   doctest Signet.OpenChain.Signatures
   doctest Signet.OpenChain.API
 
-
   defmodule TestClient do
     @lookup_success ~S"""
     {
@@ -26,7 +25,11 @@ defmodule Signet.OpenChainTest do
     }
     """
 
-    def get("https://example.com/open-chain/signature-database/v1/lookup?" <> _params, _headers, _opts) do
+    def get(
+          "https://example.com/open-chain/signature-database/v1/lookup?" <> _params,
+          _headers,
+          _opts
+        ) do
       {:ok, %HTTPoison.Response{status_code: 200, body: @lookup_success}}
     end
   end


### PR DESCRIPTION
This patch simply fixes the OpenChain API Parameters, per the spec https://docs.openchain.xyz/#/default/get_signature_database_v1_lookup. Note: it's event= and function=, despite being lists