### PR TITLE
Filter No Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0-delta6
+
+- [Filter No Address](https://github.com/hayesgm/signet/pull/64)
+
 ## v1.0.0-delta5
 
 - [Sleuth Binaries](https://github.com/hayesgm/signet/pull/63)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-delta5"}
+    {:signet, "~> 1.0.0-delta6"}
   ]
 end
 ```

--- a/lib/signet/filter.ex
+++ b/lib/signet/filter.ex
@@ -53,7 +53,7 @@ defmodule Signet.Filter do
 
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
-    address = Keyword.fetch!(opts, :address)
+    address = Keyword.get(opts, :address, nil)
     topics = Keyword.get(opts, :topics, [])
     events = Keyword.get(opts, :events, [])
     rpc_opts = Keyword.get(opts, :rpc_opts, [])
@@ -96,6 +96,21 @@ defmodule Signet.Filter do
       },
       name: name
     )
+  end
+
+  defp set_filter(state = %{address: nil, topics: topics, rpc_opts: rpc_opts}) do
+    {:ok, filter_id} =
+      RPC.send_rpc(
+        "eth_newFilter",
+        [
+          %{
+            "topics" => Enum.map(topics, &Signet.Hex.encode_hex/1)
+          }
+        ],
+        rpc_opts
+      )
+
+    Map.put(state, :filter_id, filter_id)
   end
 
   defp set_filter(state = %{address: address, topics: topics, rpc_opts: rpc_opts}) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-delta5",
+      version: "1.0.0-delta6",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch adds the ability to filter without an address (e.g. on all addresses) when creating a Filter in Signet.

bump to delta6