### PR TITLE
fix typo on Utils.encode_hex deprecation message

### DIFF
--- a/lib/signet/util.ex
+++ b/lib/signet/util.ex
@@ -163,7 +163,7 @@ defmodule Signet.Util do
     iex> Signet.Util.encode_hex(<<0x0>>, true)
     "0x0"
   """
-  @deprecated "Use Signet.Hex.encode_hex_short/1 instead"
+  @deprecated "Use Signet.Hex.encode_short_hex/1 instead"
   def encode_hex(hex, short \\ false)
   def encode_hex(nil, _short), do: nil
 


### PR DESCRIPTION
encode_hex_short does not exist