### PR TITLE
Trace Reverts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.0.0-delta7
+
+- [Fix Test Runner](https://github.com/hayesgm/signet/pull/67)
+- [Trace Reverts](https://github.com/hayesgm/signet/pull/66)
+- [Fix Typo](https://github.com/hayesgm/signet/pull/65)
+
 ## v1.0.0-delta6
 
 - [Filter No Address](https://github.com/hayesgm/signet/pull/64)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-delta6"}
+    {:signet, "~> 1.0.0-delta7"}
   ]
 end
 ```

--- a/lib/signet/sleuth.ex
+++ b/lib/signet/sleuth.ex
@@ -115,7 +115,7 @@ defmodule Signet.Sleuth do
     end
   end
 
-  defp unwrap_outer_tuple(xs=%{"var0" => x}) when map_size(xs) == 1, do: x
+  defp unwrap_outer_tuple(xs = %{"var0" => x}) when map_size(xs) == 1, do: x
   defp unwrap_outer_tuple(els), do: els
 
   defp try_apply(mod, fun, args) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-delta6",
+      version: "1.0.0-delta7",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/sleuth_test.exs
+++ b/test/sleuth_test.exs
@@ -14,6 +14,21 @@ defmodule SleuthTest do
                )
     end
 
+    test "query() failure with trace" do
+      assert {:error,
+              %{
+                code: 3,
+                message: "execution reverted",
+                trace: _
+              }} =
+               Signet.Sleuth.query(
+                 ~h[],
+                 ~h[0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF00000001],
+                 Signet.Contract.BlockNumber.query_selector(),
+                 trace_reverts: true
+               )
+    end
+
     test "query_by() via mod/fun" do
       assert {:ok, %{"blockNumber" => 2}} ==
                Signet.Sleuth.query_by(
@@ -73,7 +88,8 @@ defmodule SleuthTest do
     end
 
     test "queryFour() - no decode binaries" do
-      assert {:ok, %{"var0" => "0x010203", "var1" => "0x0000000000000000000000000000000000000001"}} ==
+      assert {:ok,
+              %{"var0" => "0x010203", "var1" => "0x0000000000000000000000000000000000000001"}} ==
                Signet.Sleuth.query(
                  Signet.Contract.BlockNumber.bytecode(),
                  Signet.Contract.BlockNumber.encode_query_four(),

--- a/test/support/signet/sleuth_handler.ex
+++ b/test/support/signet/sleuth_handler.ex
@@ -15,19 +15,25 @@ defmodule Signet.Test.SleuthHandler do
         encode_sleuth(Signet.Contract.BlockNumber.query_selector(), {2})
 
       {:ok, "queryTwo", _} ->
-      encode_sleuth(Signet.Contract.BlockNumber.query_two_selector(), {2, 3})
+        encode_sleuth(Signet.Contract.BlockNumber.query_two_selector(), {2, 3})
 
       {:ok, "queryThree", _} ->
         encode_sleuth(Signet.Contract.BlockNumber.query_three_selector(), {2})
 
       {:ok, "queryFour", _} ->
-        encode_sleuth(Signet.Contract.BlockNumber.query_four_selector(), {~h[0x010203], ~h[0x0000000000000000000000000000000000000001]})
+        encode_sleuth(
+          Signet.Contract.BlockNumber.query_four_selector(),
+          {~h[0x010203], ~h[0x0000000000000000000000000000000000000001]}
+        )
 
       {:ok, "queryCool", _} ->
-        encode_sleuth(Signet.Contract.BlockNumber.query_cool_selector(), {{"hi", [1, 2, 3], {"meow"}}})
-      
+        encode_sleuth(
+          Signet.Contract.BlockNumber.query_cool_selector(),
+          {{"hi", [1, 2, 3], {"meow"}}}
+        )
+
       _ ->
-        raise "Unknown Sleuth query call" 
+        raise "Unknown Sleuth query call"
     end
   end
 
@@ -46,7 +52,7 @@ defmodule Signet.Test.SleuthHandler do
         {:error,
          %{
            "code" => 3,
-           "message" => "unexpected"
+           "message" => "execution reverted"
          }}
 
       true ->


### PR DESCRIPTION
This patch adds the ability to easily trace reverts on `call_trx` calls, e.g. so you can easily see the revert reasons. This simply has the ability to try and trace a call after it reverts (by setting `trace_reverts: true`) and then an error that reverted will include a `trace: Trace{}` field that can be observed.

Bump to delta7