### PR TITLE
Fix Test Runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "25.0"
-          elixir-version: "1.13.4"
+          otp-version: "26.1.2"
+          elixir-version: "1.16.1"
 
       - name: Elixir Dependencies
         run: mix deps.get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Signet Tests
 
 on:
-  - pull_request
+  - push
 
 jobs:
   build-test:
@@ -20,8 +20,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "25.0"
-          elixir-version: "1.13.4"
+          otp-version: "26.1.2"
+          elixir-version: "1.16.1"
 
       - name: Elixir Dependencies
         run: mix deps.get


### PR DESCRIPTION
This patch fixes the GitHub test runner, by just bumping the versions of Elixir and OTP.