### PR TITLE
Fix Decode Event Codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0-delta8
+
+- [Fix Decode Event Codegen](https://github.com/hayesgm/signet/pull/68)
+
 ## v1.0.0-delta7
 
 - [Fix Test Runner](https://github.com/hayesgm/signet/pull/67)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-delta7"}
+    {:signet, "~> 1.0.0-delta8"}
   ]
 end
 ```

--- a/lib/mix/signet.gen.ex
+++ b/lib/mix/signet.gen.ex
@@ -183,7 +183,7 @@ defmodule Mix.Tasks.Signet.Gen do
 
     events = [
       quote do
-        def decode_event(_), do: :not_found
+        def decode_event(_, _), do: :not_found
       end
       | events
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-delta7",
+      version: "1.0.0-delta8",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This fixes a bug where the `decode_event` function was defined with the wrong number of parameters.

Bumps version to delta8