### PR TITLE
safely decode nil results to error tuple, function to return error sig and decoded values

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-echo4"}
+    {:signet, "~> 1.0.0-echo5"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-echo4",
+      version: "1.0.0-echo5",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch deals with a umatched function sigs crashing since the api response is e.g. `%{"event" => %{}, "function" => %{"0x8379a000" => nil}}` rather than an intuitive empty map or list.

It also adds a function to decode an error signaturea nd it's argument in one call.