### PR TITLE
Add TStore Support [echo7]

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.0.0-echo6"}
+    {:signet, "~> 1.0.0-echo7"}
   ]
 end
 ```

--- a/lib/signet/assembly.ex
+++ b/lib/signet/assembly.ex
@@ -117,6 +117,8 @@ defmodule Signet.Assembly do
     msize: {<<0x59>>, 0, 1},
     gas: {<<0x5A>>, 0, 1},
     jumpdest: {<<0x5B>>, 0, 0},
+    tload: {<<0x5C>>, 1, 1},
+    tstore: {<<0x5D>>, 2, 0},
     # push 0x5f-7f
     # dup 0x80-8f
     # swap 0x90-9f

--- a/lib/signet/typed.ex
+++ b/lib/signet/typed.ex
@@ -292,7 +292,9 @@ defmodule Signet.Typed do
     def encode_data_value(value, :string), do: Signet.Hash.keccak(value)
     def encode_data_value(value, :bytes), do: Signet.Hash.keccak(value)
     def encode_data_value(value, {:bytes, _}), do: Signet.Util.pad(value, 32)
-    def encode_data_value(value, :bool), do: encode_data_value((if value, do: 1, else: 0), {:uint, 256})
+
+    def encode_data_value(value, :bool),
+      do: encode_data_value(if(value, do: 1, else: 0), {:uint, 256})
 
     def encode_data_value(value, {:array, ty}) do
       value

--- a/lib/signet/vm.ex
+++ b/lib/signet/vm.ex
@@ -47,6 +47,7 @@ defmodule Signet.VM do
       :halted,
       :stack,
       :memory,
+      :tstorage,
       :reverted,
       :return_data
     ]
@@ -60,6 +61,7 @@ defmodule Signet.VM do
             halted: binary(),
             stack: [binary()],
             memory: binary(),
+            tstorage: %{binary() => binary()},
             reverted: boolean(),
             return_data: binary()
           }
@@ -76,6 +78,7 @@ defmodule Signet.VM do
         halted: false,
         stack: [],
         memory: <<>>,
+        tstorage: %{},
         reverted: false,
         return_data: <<>>
       }
@@ -632,6 +635,16 @@ defmodule Signet.VM do
 
         :jumpdest ->
           {:ok, context}
+
+        :tload ->
+          with {:ok, context, res} <- pop_unsigned(context) do
+            push_word(context, Map.get(context.tstorage, res, <<0::256>>))
+          end
+
+        :tstore ->
+          with {:ok, context, key, value} <- pop2_unsigned_word(context) do
+            {:ok, %{context | tstorage: Map.put(context.tstorage, key, value)}}
+          end
 
         {:push, n, v} ->
           push_n(context, n, v)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.0.0-echo6",
+      version: "1.0.0-echo7",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vm_test.exs
+++ b/test/vm_test.exs
@@ -1290,6 +1290,34 @@ defmodule Signet.VmTest do
       ]
     },
     %{
+      name: "TStore -> TLoad",
+      code: [
+        {:push, 32, word("0x112233445566778899aabbccddeeff112233445566778899aabbccddeeff1122")},
+        {:push, 32, word(100)},
+        :tstore,
+        {:push, 32, word(110)},
+        :tload,
+        :stop
+      ],
+      exp_stack: [
+        ~h[0x0000000000000000000000000000000000000000000000000000000000000000]
+      ]
+    },
+    %{
+      name: "TStore -> TLoad Match",
+      code: [
+        {:push, 32, word("0x112233445566778899aabbccddeeff112233445566778899aabbccddeeff1122")},
+        {:push, 32, word(100)},
+        :tstore,
+        {:push, 32, word(100)},
+        :tload,
+        :stop
+      ],
+      exp_stack: [
+        ~h[0x112233445566778899aabbccddeeff112233445566778899aabbccddeeff1122]
+      ]
+    },
+    %{
       name: "Dup1",
       code: [
         {:push, 32, word(0x100)},


### PR DESCRIPTION
This patch adds `tstore` support for the EVM-VM and bumps to echo7.