### PR TITLE
Add FFI Integration

### DIFF
--- a/lib/mix/signet.gen.ex
+++ b/lib/mix/signet.gen.ex
@@ -529,12 +529,12 @@ defmodule Mix.Tasks.Signet.Gen do
         quote do
           def unquote(exec_vm_fun_name)(
                 unquote_splicing(execute_arguments),
-                callvalue \\ 0
+                exec_opts \\ []
               ) do
             case Signet.VM.exec_call(
                    deployed_bytecode(),
                    unquote(encode_fun_name)(unquote_splicing(execute_values)),
-                   callvalue
+                   exec_opts
                  ) do
               {:ok, return_data} ->
                 case ABI.decode(
@@ -547,6 +547,9 @@ defmodule Mix.Tasks.Signet.Gen do
 
                   [decoded] ->
                     {:ok, decoded}
+
+                  els ->
+                    {:ok, els}
                 end
 
               {:revert, revert_data} ->
@@ -565,12 +568,12 @@ defmodule Mix.Tasks.Signet.Gen do
         quote do
           def unquote(exec_vm_raw_fun_name)(
                 unquote_splicing(execute_arguments),
-                callvalue \\ 0
+                exec_opts \\ []
               ) do
             Signet.VM.exec_call(
               deployed_bytecode(),
               unquote(encode_fun_name)(unquote_splicing(execute_values)),
-              callvalue
+              exec_opts
             )
           end
         end

--- a/test/support/signet/contract/block_number.ex
+++ b/test/support/signet/contract/block_number.ex
@@ -46,6 +46,7 @@ defmodule Signet.Contract.BlockNumber do
   end
 
   def decode_query_call(<<44, 70, 178, 5>> <> calldata) do
+    _signature = hex!("0x2c46b205")
     ABI.decode(query_selector(), calldata)
   end
 
@@ -96,24 +97,31 @@ defmodule Signet.Contract.BlockNumber do
   end
 
   def decode_query_cool_call(<<107, 188, 156, 20>> <> calldata) do
+    _signature = hex!("0x6bbc9c14")
     ABI.decode(query_cool_selector(), calldata)
   end
 
-  def exec_vm_query_cool(callvalue \\ 0) do
-    case Signet.VM.exec_call(deployed_bytecode(), encode_query_cool(), callvalue) do
+  def exec_vm_query_cool(exec_opts \\ []) do
+    case Signet.VM.exec_call(deployed_bytecode(), encode_query_cool(), exec_opts) do
       {:ok, return_data} ->
-        {:ok,
-         ABI.decode(%ABI.FunctionSelector{types: query_cool_selector().returns}, return_data)}
+        case ABI.decode(%ABI.FunctionSelector{types: query_cool_selector().returns}, return_data,
+               decode_structs: true
+             ) do
+          m when is_map(m) -> {:ok, m}
+          [decoded] -> {:ok, decoded}
+          els -> {:ok, els}
+        end
 
       {:revert, revert_data} ->
-        with :not_found <- decode_error(revert_data) do
-          {:revert, "Unknown", revert_data}
+        case decode_error(revert_data) do
+          {:ok, error, data} -> {:revert, error, data}
+          :not_found -> {:revert, "Unknown", revert_data}
         end
     end
   end
 
-  def exec_vm_query_cool_raw(callvalue \\ 0) do
-    Signet.VM.exec_call(deployed_bytecode(), encode_query_cool(), callvalue)
+  def exec_vm_query_cool_raw(exec_opts \\ []) do
+    Signet.VM.exec_call(deployed_bytecode(), encode_query_cool(), exec_opts)
   end
 
   def query_four_selector() do
@@ -152,24 +160,31 @@ defmodule Signet.Contract.BlockNumber do
   end
 
   def decode_query_four_call(<<160, 180, 62, 214>> <> calldata) do
+    _signature = hex!("0xa0b43ed6")
     ABI.decode(query_four_selector(), calldata)
   end
 
-  def exec_vm_query_four(callvalue \\ 0) do
-    case Signet.VM.exec_call(deployed_bytecode(), encode_query_four(), callvalue) do
+  def exec_vm_query_four(exec_opts \\ []) do
+    case Signet.VM.exec_call(deployed_bytecode(), encode_query_four(), exec_opts) do
       {:ok, return_data} ->
-        {:ok,
-         ABI.decode(%ABI.FunctionSelector{types: query_four_selector().returns}, return_data)}
+        case ABI.decode(%ABI.FunctionSelector{types: query_four_selector().returns}, return_data,
+               decode_structs: true
+             ) do
+          m when is_map(m) -> {:ok, m}
+          [decoded] -> {:ok, decoded}
+          els -> {:ok, els}
+        end
 
       {:revert, revert_data} ->
-        with :not_found <- decode_error(revert_data) do
-          {:revert, "Unknown", revert_data}
+        case decode_error(revert_data) do
+          {:ok, error, data} -> {:revert, error, data}
+          :not_found -> {:revert, "Unknown", revert_data}
         end
     end
   end
 
-  def exec_vm_query_four_raw(callvalue \\ 0) do
-    Signet.VM.exec_call(deployed_bytecode(), encode_query_four(), callvalue)
+  def exec_vm_query_four_raw(exec_opts \\ []) do
+    Signet.VM.exec_call(deployed_bytecode(), encode_query_four(), exec_opts)
   end
 
   def query_three_selector() do
@@ -208,6 +223,7 @@ defmodule Signet.Contract.BlockNumber do
   end
 
   def decode_query_three_call(<<219, 127, 37, 93>> <> calldata) do
+    _signature = hex!("0xdb7f255d")
     ABI.decode(query_three_selector(), calldata)
   end
 
@@ -247,26 +263,32 @@ defmodule Signet.Contract.BlockNumber do
   end
 
   def decode_query_two_call(<<53, 0, 122, 122>> <> calldata) do
+    _signature = hex!("0x35007a7a")
     ABI.decode(query_two_selector(), calldata)
   end
 
   def decode_call(calldata = <<44, 70, 178, 5>> <> _) do
+    _signature = hex!("0x2c46b205")
     {:ok, "query", decode_query_call(calldata)}
   end
 
   def decode_call(calldata = <<107, 188, 156, 20>> <> _) do
+    _signature = hex!("0x6bbc9c14")
     {:ok, "queryCool", decode_query_cool_call(calldata)}
   end
 
   def decode_call(calldata = <<160, 180, 62, 214>> <> _) do
+    _signature = hex!("0xa0b43ed6")
     {:ok, "queryFour", decode_query_four_call(calldata)}
   end
 
   def decode_call(calldata = <<219, 127, 37, 93>> <> _) do
+    _signature = hex!("0xdb7f255d")
     {:ok, "queryThree", decode_query_three_call(calldata)}
   end
 
   def decode_call(calldata = <<53, 0, 122, 122>> <> _) do
+    _signature = hex!("0x35007a7a")
     {:ok, "queryTwo", decode_query_two_call(calldata)}
   end
 

--- a/test/support/signet/contract/ierc20.ex
+++ b/test/support/signet/contract/ierc20.ex
@@ -46,6 +46,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_allowance_call(<<221, 98, 237, 62>> <> calldata) do
+    _signature = hex!("0xdd62ed3e")
     ABI.decode(allowance_selector(), calldata)
   end
 
@@ -85,6 +86,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_approve_call(<<9, 94, 167, 179>> <> calldata) do
+    _signature = hex!("0x095ea7b3")
     ABI.decode(approve_selector(), calldata)
   end
 
@@ -124,6 +126,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_balance_of_call(<<112, 160, 130, 49>> <> calldata) do
+    _signature = hex!("0x70a08231")
     ABI.decode(balance_of_selector(), calldata)
   end
 
@@ -163,6 +166,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_decimals_call(<<49, 60, 229, 103>> <> calldata) do
+    _signature = hex!("0x313ce567")
     ABI.decode(decimals_selector(), calldata)
   end
 
@@ -202,6 +206,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_name_call(<<6, 253, 222, 3>> <> calldata) do
+    _signature = hex!("0x06fdde03")
     ABI.decode(name_selector(), calldata)
   end
 
@@ -241,6 +246,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_symbol_call(<<149, 216, 155, 65>> <> calldata) do
+    _signature = hex!("0x95d89b41")
     ABI.decode(symbol_selector(), calldata)
   end
 
@@ -280,6 +286,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_total_supply_call(<<24, 22, 13, 221>> <> calldata) do
+    _signature = hex!("0x18160ddd")
     ABI.decode(total_supply_selector(), calldata)
   end
 
@@ -319,6 +326,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_transfer_call(<<169, 5, 156, 187>> <> calldata) do
+    _signature = hex!("0xa9059cbb")
     ABI.decode(transfer_selector(), calldata)
   end
 
@@ -362,6 +370,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_transfer_from_call(<<35, 184, 114, 221>> <> calldata) do
+    _signature = hex!("0x23b872dd")
     ABI.decode(transfer_from_selector(), calldata)
   end
 
@@ -385,6 +394,7 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_approval_event(topics, data) when is_list(topics) do
+    _signature = hex!("0x8c5be1e5")
     ABI.Event.decode_event(data, topics, approval_event_selector())
   end
 
@@ -408,42 +418,52 @@ defmodule Signet.Contract.IERC20 do
   end
 
   def decode_transfer_ddf252ad_event(topics, data) when is_list(topics) do
+    _signature = hex!("0xddf252ad")
     ABI.Event.decode_event(data, topics, transfer_ddf252ad_event_selector())
   end
 
   def decode_call(calldata = <<221, 98, 237, 62>> <> _) do
+    _signature = hex!("0xdd62ed3e")
     {:ok, "allowance", decode_allowance_call(calldata)}
   end
 
   def decode_call(calldata = <<9, 94, 167, 179>> <> _) do
+    _signature = hex!("0x095ea7b3")
     {:ok, "approve", decode_approve_call(calldata)}
   end
 
   def decode_call(calldata = <<112, 160, 130, 49>> <> _) do
+    _signature = hex!("0x70a08231")
     {:ok, "balanceOf", decode_balance_of_call(calldata)}
   end
 
   def decode_call(calldata = <<49, 60, 229, 103>> <> _) do
+    _signature = hex!("0x313ce567")
     {:ok, "decimals", decode_decimals_call(calldata)}
   end
 
   def decode_call(calldata = <<6, 253, 222, 3>> <> _) do
+    _signature = hex!("0x06fdde03")
     {:ok, "name", decode_name_call(calldata)}
   end
 
   def decode_call(calldata = <<149, 216, 155, 65>> <> _) do
+    _signature = hex!("0x95d89b41")
     {:ok, "symbol", decode_symbol_call(calldata)}
   end
 
   def decode_call(calldata = <<24, 22, 13, 221>> <> _) do
+    _signature = hex!("0x18160ddd")
     {:ok, "totalSupply", decode_total_supply_call(calldata)}
   end
 
   def decode_call(calldata = <<169, 5, 156, 187>> <> _) do
+    _signature = hex!("0xa9059cbb")
     {:ok, "transfer", decode_transfer_call(calldata)}
   end
 
   def decode_call(calldata = <<35, 184, 114, 221>> <> _) do
+    _signature = hex!("0x23b872dd")
     {:ok, "transferFrom", decode_transfer_from_call(calldata)}
   end
 

--- a/test/support/signet/contract/rock.ex
+++ b/test/support/signet/contract/rock.ex
@@ -75,14 +75,15 @@ defmodule Signet.Contract.Rock do
     ABI.decode(jam_selector(), calldata)
   end
 
-  def exec_vm_jam(beats, callvalue \\ 0) do
-    case Signet.VM.exec_call(deployed_bytecode(), encode_jam(beats), callvalue) do
+  def exec_vm_jam(beats, exec_opts \\ []) do
+    case Signet.VM.exec_call(deployed_bytecode(), encode_jam(beats), exec_opts) do
       {:ok, return_data} ->
         case ABI.decode(%ABI.FunctionSelector{types: jam_selector().returns}, return_data,
                decode_structs: true
              ) do
           m when is_map(m) -> {:ok, m}
           [decoded] -> {:ok, decoded}
+          els -> {:ok, els}
         end
 
       {:revert, revert_data} ->
@@ -93,8 +94,8 @@ defmodule Signet.Contract.Rock do
     end
   end
 
-  def exec_vm_jam_raw(beats, callvalue \\ 0) do
-    Signet.VM.exec_call(deployed_bytecode(), encode_jam(beats), callvalue)
+  def exec_vm_jam_raw(beats, exec_opts \\ []) do
+    Signet.VM.exec_call(deployed_bytecode(), encode_jam(beats), exec_opts)
   end
 
   def stumble_144e59d6_selector() do
@@ -137,8 +138,8 @@ defmodule Signet.Contract.Rock do
     ABI.decode(stumble_144e59d6_selector(), calldata)
   end
 
-  def exec_vm_stumble_144e59d6(callvalue \\ 0) do
-    case Signet.VM.exec_call(deployed_bytecode(), encode_stumble_144e59d6(), callvalue) do
+  def exec_vm_stumble_144e59d6(exec_opts \\ []) do
+    case Signet.VM.exec_call(deployed_bytecode(), encode_stumble_144e59d6(), exec_opts) do
       {:ok, return_data} ->
         case ABI.decode(
                %ABI.FunctionSelector{types: stumble_144e59d6_selector().returns},
@@ -147,6 +148,7 @@ defmodule Signet.Contract.Rock do
              ) do
           m when is_map(m) -> {:ok, m}
           [decoded] -> {:ok, decoded}
+          els -> {:ok, els}
         end
 
       {:revert, revert_data} ->
@@ -157,8 +159,8 @@ defmodule Signet.Contract.Rock do
     end
   end
 
-  def exec_vm_stumble_144e59d6_raw(callvalue \\ 0) do
-    Signet.VM.exec_call(deployed_bytecode(), encode_stumble_144e59d6(), callvalue)
+  def exec_vm_stumble_144e59d6_raw(exec_opts \\ []) do
+    Signet.VM.exec_call(deployed_bytecode(), encode_stumble_144e59d6(), exec_opts)
   end
 
   def decode_call(calldata = <<191, 104, 23, 16>> <> _) do


### PR DESCRIPTION
This patch adds the ability to call into FFI "foreign-function interfaces," which are hooks back into the EVM's calling context environment. From the perspective of the EVM/Solidity code, this is the same as calling a standard Ethereum precompile (e.g. these functions: https://www.evm.codes/precompiled), but overall, this means we can allow hooks from EVM-VM code, e.g. to fetch offline price data. This lightly violates the concept of being pure, but overall, it's up to the discretion of the author to add hooks or not into code.

Note: we change the signature of `Signet.VM.exec` and `Signet.VM.exec_call` to use `exec_opts`, which allows FFIs, and thus, we change some of our generated code, as well, to match this new format.

Note: we only allow `STATICCALL` right now, but we could easily add support for other call types if that becomes interesting.