### PR TITLE
bugfix: when decode_binaries is false, do not decode sized bytes

### DIFF
--- a/lib/signet/sleuth.ex
+++ b/lib/signet/sleuth.ex
@@ -103,6 +103,9 @@ defmodule Signet.Sleuth do
             {:bytes, false} ->
               to_hex(res)
 
+            {{:bytes, _size}, false} ->
+              to_hex(res)
+
             _ ->
               res
           end


### PR DESCRIPTION
pretty much what it says in the title.