### PR TITLE
Send Gas Limit [v1.2.1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.2.0"}
+    {:signet, "~> 1.2.1"}
   ]
 end
 ```

--- a/lib/signet/rpc.ex
+++ b/lib/signet/rpc.ex
@@ -1466,6 +1466,7 @@ defmodule Signet.RPC do
       from: nil_map(from, &Hex.encode_big_hex/1),
       to: nil_map(trx.to, &Hex.encode_big_hex/1),
       gasPrice: nil_map(trx.gas_price, &Hex.encode_short_hex/1),
+      gas: nil_map(trx.gas_limit, &Hex.encode_short_hex/1),
       value: nil_map(trx.value, &Hex.encode_short_hex/1),
       data: nil_map(trx.data, &Hex.encode_short_hex/1)
     }
@@ -1477,6 +1478,7 @@ defmodule Signet.RPC do
       to: nil_map(trx.destination, &Hex.encode_big_hex/1),
       maxPriorityFeePerGas: nil_map(trx.max_priority_fee_per_gas, &Hex.encode_short_hex/1),
       maxFeePerGas: nil_map(trx.max_fee_per_gas, &Hex.encode_short_hex/1),
+      gas: nil_map(trx.gas_limit, &Hex.encode_short_hex/1),
       value: nil_map(trx.amount, &Hex.encode_short_hex/1),
       data: nil_map(trx.data, &Hex.encode_big_hex/1)
     }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.2.0",
+      version: "1.2.1",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vm_test.exs
+++ b/test/vm_test.exs
@@ -1555,7 +1555,7 @@ defmodule Signet.VmTest do
         <<1::160>> => &FFI.simple_ffi/1
       },
       code: [
-        {:push, 32, word("0x0x9905b744")},
+        {:push, 32, word("0x9905b744")},
         {:push, 32, word(100-28)},
         :mstore,
         {:push, 32, word("0x0000000000000000000000000000000000000000000000000000000000000037")},


### PR DESCRIPTION
This patch fixes our `to_call_params` function to send the `"gas"` parameter, based on the `gas_limit` value in the transaction. We previously only sent the gas limit with transactions.

We also fix a small typo in a vm test.

See: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_call