### PR TITLE
Fix VM div/sdiv [Bump to 1.2.3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.2.2"}
+    {:signet, "~> 1.2.3"}
   ]
 end
 ```

--- a/lib/signet/vm.ex
+++ b/lib/signet/vm.ex
@@ -43,7 +43,9 @@ defmodule Signet.VM do
     def log_ffi(args) do
       case Signet.Contract.IConsole.decode_call(args) do
         {:ok, f, values} ->
-          IO.puts("console.#{f}: #{inspect(values, limit: :infinity, printable_limit: :infinity)}")
+          IO.puts(
+            "console.#{f}: #{inspect(values, limit: :infinity, printable_limit: :infinity)}"
+          )
 
         _ ->
           nil
@@ -568,10 +570,10 @@ defmodule Signet.VM do
           unsigned_op2(context, &rem(&1 * &2, @two_pow_256))
 
         :div ->
-          unsigned_op2(context, &if(&2 == 0, do: 0, else: floor(&1 / &2)))
+          unsigned_op2(context, &if(&2 == 0, do: 0, else: Integer.floor_div(&1, &2)))
 
         :sdiv ->
-          signed_op2(context, &if(&2 == 0, do: 0, else: floor(&1 / &2)))
+          signed_op2(context, &if(&2 == 0, do: 0, else: Integer.floor_div(&1, &2)))
 
         :mod ->
           unsigned_op2(context, &if(&2 == 0, do: 0, else: rem(&1, &2)))
@@ -890,10 +892,13 @@ defmodule Signet.VM do
   end
 
   def exec(code, calldata, opts) when is_list(code) do
-    run_code(Context.init_from(code, Map.merge(@builtin_ffis, Keyword.get(opts, :ffis, %{}))), %Input{
-      calldata: calldata,
-      value: Keyword.get(opts, :callvalue, 0)
-    })
+    run_code(
+      Context.init_from(code, Map.merge(@builtin_ffis, Keyword.get(opts, :ffis, %{}))),
+      %Input{
+        calldata: calldata,
+        value: Keyword.get(opts, :callvalue, 0)
+      }
+    )
   end
 
   defmodule VmError do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.2.2",
+      version: "1.2.3",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vm_test.exs
+++ b/test/vm_test.exs
@@ -132,6 +132,18 @@ defmodule Signet.VmTest do
       ]
     },
     %{
+      name: "Large Div",
+      code: [
+        {:push, 32, word(0x989680)},
+        {:push, 32, word(0x84595161401484A000000)},
+        :div,
+        :stop
+      ],
+      exp_stack: [
+        word(0xDE0B6B3A7640000)
+      ]
+    },
+    %{
       name: "Simple Div Zero",
       code: [
         {:push, 32, word(0x00)},
@@ -153,6 +165,18 @@ defmodule Signet.VmTest do
       ],
       exp_stack: [
         word(0x03)
+      ]
+    },
+    %{
+      name: "Large SDiv",
+      code: [
+        {:push, 32, word(0x989680)},
+        {:push, 32, word(0x84595161401484A000000)},
+        :sdiv,
+        :stop
+      ],
+      exp_stack: [
+        word(0xDE0B6B3A7640000)
       ]
     },
     %{
@@ -1556,7 +1580,7 @@ defmodule Signet.VmTest do
       },
       code: [
         {:push, 32, word("0x9905b744")},
-        {:push, 32, word(100-28)},
+        {:push, 32, word(100 - 28)},
         :mstore,
         {:push, 32, word("0x0000000000000000000000000000000000000000000000000000000000000037")},
         {:push, 32, word(104)},


### PR DESCRIPTION
We previously used `floor(a/b)` for integer math, but this ends up using floating point math and can lead to rounding issues. We replace this with `Integer.floor_div/2`, which fixes the issue as elucidated in the VM test. This caused issues on checking Solidity overflow math.

See also: https://hexdocs.pm/elixir/Integer.html#floor_div/2