### PR TITLE
Debugging Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.2.5"}
+    {:signet, "~> 1.2.6"}
   ]
 end
 ```

--- a/lib/signet/assembly.ex
+++ b/lib/signet/assembly.ex
@@ -492,4 +492,268 @@ defmodule Signet.Assembly do
         {:codecopy, 0x00, :self_code_sz, byte_size(code)},
         {:return, 0x00, byte_size(code)}
       ]) <> code
+
+  @doc """
+  Returns a textual representation of the given operation.
+
+  ## Examples
+
+      iex> Signet.Assembly.show_opcode(:add)
+      "ADD"
+
+      iex> Signet.Assembly.show_opcode({:push, 5, <<1,2,3,4,5>>})
+      "PUSH5 0x0102030405"
+  """
+  def show_opcode(op) do
+    case op do
+      :stop ->
+        "STOP"
+
+      :add ->
+        "ADD"
+
+      :sub ->
+        "SUB"
+
+      :mul ->
+        "MUL"
+
+      :div ->
+        "DIV"
+
+      :sdiv ->
+        "SDIV"
+
+      :mod ->
+        "MOD"
+
+      :smod ->
+        "SMOD"
+
+      :addmod ->
+        "ADDMOD"
+
+      :mulmod ->
+        "MULMOD"
+
+      :exp ->
+        "EXP"
+
+      :signextend ->
+        "SIGNEXTEND"
+
+      :lt ->
+        "LT"
+
+      :gt ->
+        "GT"
+
+      :slt ->
+        "SLT"
+
+      :sgt ->
+        "SGT"
+
+      :eq ->
+        "EQ"
+
+      :iszero ->
+        "ISZERO"
+
+      :and ->
+        "AND"
+
+      :or ->
+        "OR"
+
+      :xor ->
+        "XOR"
+
+      :not ->
+        "NOT"
+
+      :byte ->
+        "BYTE"
+
+      :shl ->
+        "SHL"
+
+      :shr ->
+        "SHR"
+
+      :sar ->
+        "SAR"
+
+      :sha3 ->
+        "SHA3"
+
+      :callvalue ->
+        "CALLVALUE"
+
+      :calldataload ->
+        "CALLDATALOAD"
+
+      :calldatasize ->
+        "CALLDATASIZE"
+
+      :calldatacopy ->
+        "CALLDATACOPY"
+
+      :codesize ->
+        "CODESIZE"
+
+      :codecopy ->
+        "CODECOPY"
+
+      :pop ->
+        "POP"
+
+      :mload ->
+        "MLOAD"
+
+      :mstore ->
+        "MSTORE"
+
+      :mstore8 ->
+        "MSTORE8"
+
+      :jump ->
+        "JUMP"
+
+      :jumpi ->
+        "JUMPI"
+
+      :pc ->
+        "PC"
+
+      :msize ->
+        "MSIZE"
+
+      :gas ->
+        "GAS"
+
+      :jumpdest ->
+        "JUMPDEST"
+
+      :tload ->
+        "TLOAD"
+
+      :tstore ->
+        "TSTORE"
+
+      :mcopy ->
+        "MCOPY"
+
+      {:push, n, v} ->
+        "PUSH#{n} #{to_hex(v)}"
+
+      {:dup, n} ->
+        "DUP#{n}"
+
+      {:swap, n} ->
+        "SWAP#{n}"
+
+      :return ->
+        "RETURN"
+
+      :revert ->
+        "REVERT"
+
+      {:invalid, _} ->
+        "INVALID"
+
+      :staticcall ->
+        "STATICCALL"
+
+      :returndatasize ->
+        "RETURNDATASIZE"
+
+      :returndatacopy ->
+        "RETURNDATACOPY"
+
+      :address ->
+        "ADDRESS"
+
+      :balance ->
+        "BALANCE"
+
+      :origin ->
+        "ORIGIN"
+
+      :caller ->
+        "CALLER"
+
+      :gasprice ->
+        "GASPRICE"
+
+      :extcodesize ->
+        "EXTCODESIZE"
+
+      :extcodecopy ->
+        "EXTCODECOPY"
+
+      :extcodehash ->
+        "EXTCODEHASH"
+
+      :blockhash ->
+        "BLOCKHASH"
+
+      :coinbase ->
+        "COINBASE"
+
+      :timestamp ->
+        "TIMESTAMP"
+
+      :number ->
+        "NUMBER"
+
+      :prevrandao ->
+        "PREVRANDAO"
+
+      :gaslimit ->
+        "GASLIMIT"
+
+      :chainid ->
+        "CHAINID"
+
+      :selfbalance ->
+        "SELFBALANCE"
+
+      :basefee ->
+        "BASEFEE"
+
+      :blobhash ->
+        "BLOBHASH"
+
+      :blobbasefee ->
+        "BLOBBASEFEE"
+
+      :sload ->
+        "SLOAD"
+
+      :sstore ->
+        "SSTORE"
+
+      :log ->
+        "LOG"
+
+      :create ->
+        "CREATE"
+
+      :call ->
+        "CALL"
+
+      :callcode ->
+        "CALLCODE"
+
+      :delegatecall ->
+        "DELEGATECALL"
+
+      :create2 ->
+        "CREATE2"
+
+      :selfdestruct ->
+        "SELFDESTRUCT"
+    end
+  end
 end

--- a/lib/signet/debug_trace.ex
+++ b/lib/signet/debug_trace.ex
@@ -15,13 +15,13 @@ defmodule Signet.DebugTrace do
 
   defmodule StructLog do
     @type t() :: %__MODULE__{
-      depth: integer(),
-      gas: integer(),
-      gas_cost: integer(),
-      op: atom(),
-      pc: integer(),
-      stack: [binary()]
-    }
+            depth: integer(),
+            gas: integer(),
+            gas_cost: integer(),
+            op: atom(),
+            pc: integer(),
+            stack: [binary()]
+          }
 
     defstruct [
       :depth,
@@ -69,11 +69,11 @@ defmodule Signet.DebugTrace do
   end
 
   @type t() :: %__MODULE__{
-    failed: boolean(),
-    gas: integer(),
-    return_value: binary(),
-    struct_logs: [StructLog.t()]
-  }
+          failed: boolean(),
+          gas: integer(),
+          return_value: binary(),
+          struct_logs: [StructLog.t()]
+        }
 
   defstruct [
     :failed,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.2.5",
+      version: "1.2.6",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/client.ex
+++ b/test/support/client.ex
@@ -689,7 +689,7 @@ defmodule Signet.Test.Client do
       "structLogs" => [
         %{
           "depth" => 1,
-          "gas" => 599978568,
+          "gas" => 599_978_568,
           "gasCost" => 3,
           "op" => "PUSH1",
           "pc" => 0,
@@ -697,7 +697,7 @@ defmodule Signet.Test.Client do
         },
         %{
           "depth" => 1,
-          "gas" => 599978565,
+          "gas" => 599_978_565,
           "gasCost" => 3,
           "op" => "PUSH1",
           "pc" => 2,
@@ -705,7 +705,7 @@ defmodule Signet.Test.Client do
         },
         %{
           "depth" => 1,
-          "gas" => 599978562,
+          "gas" => 599_978_562,
           "gasCost" => 12,
           "op" => "MSTORE",
           "pc" => 4,


### PR DESCRIPTION
This patch adds a variety of logging and debugging updates to make the system a bit more manageable when debugging operations, adding trace_reverts to trx preparation and verbose options to the EVM-VM.

Bump to 1.2.6