### PR TITLE
Add Trace Serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.8
+
+- Add trace serializers
+
 ## 1.2.5
 
 - [Bump ABI Version to 1.3.0](https://github.com/hayesgm/signet/pull/96)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.2.7"}
+    {:signet, "~> 1.2.8"}
   ]
 end
 ```

--- a/lib/signet/debug_trace.ex
+++ b/lib/signet/debug_trace.ex
@@ -66,6 +66,42 @@ defmodule Signet.DebugTrace do
         stack: Enum.map(params["stack"], &Signet.Hex.decode_hex!/1)
       }
     end
+
+    @doc ~S"""
+    Serializes a trace's struct-log into a json map.
+
+    ## Examples
+
+        iex> %Signet.DebugTrace.StructLog{
+        ...>   depth: 1,
+        ...>   gas: 599978565,
+        ...>   gas_cost: 3,
+        ...>   op: :PUSH1,
+        ...>   pc: 2,
+        ...>   stack: [~h[0x80]]
+        ...> }
+        ...> |> Signet.DebugTrace.StructLog.serialize()
+        %{
+          depth: 1,
+          gas: 599978565,
+          gasCost: 3,
+          op: "PUSH1",
+          pc: 2,
+          stack: ["0x80"]
+        }
+
+    """
+    @spec serialize(t()) :: map()
+    def serialize(struct_log) do
+      %{
+        depth: struct_log.depth,
+        gas: struct_log.gas,
+        gasCost: struct_log.gas_cost,
+        op: to_string(struct_log.op),
+        pc: struct_log.pc,
+        stack: Enum.map(struct_log.stack, &Signet.Hex.to_hex/1)
+      }
+    end
   end
 
   @type t() :: %__MODULE__{
@@ -158,6 +194,85 @@ defmodule Signet.DebugTrace do
       gas: params["gas"],
       return_value: Signet.Hex.decode_hex!(params["returnValue"]),
       struct_logs: Enum.map(params["structLogs"], &StructLog.deserialize/1)
+    }
+  end
+
+  @doc ~S"""
+  Serializes a trace result back to a json map.
+
+  ## Examples
+
+      iex> %Signet.DebugTrace{
+      ...>   failed: false,
+      ...>   gas: 24034,
+      ...>   return_value: ~h[0x0000000000000000000000000000000000000000000000000858898f93629000],
+      ...>   struct_logs: [
+      ...>     %Signet.DebugTrace.StructLog{
+      ...>       depth: 1,
+      ...>       gas: 599978568,
+      ...>       gas_cost: 3,
+      ...>       op: :PUSH1,
+      ...>       pc: 0,
+      ...>       stack: []
+      ...>     },
+      ...>     %Signet.DebugTrace.StructLog{
+      ...>       depth: 1,
+      ...>       gas: 599978565,
+      ...>       gas_cost: 3,
+      ...>       op: :PUSH1,
+      ...>       pc: 2,
+      ...>       stack: [~h[0x80]]
+      ...>     },
+      ...>     %Signet.DebugTrace.StructLog{
+      ...>       depth: 1,
+      ...>       gas: 599978562,
+      ...>       gas_cost: 12,
+      ...>       op: :MSTORE,
+      ...>       pc: 4,
+      ...>       stack: [~h[0x80], ~h[0x40]]
+      ...>     }
+      ...>   ]
+      ...> }
+      ...> |> Signet.DebugTrace.serialize()
+      %{
+        failed: false,
+        gas: 24034,
+        returnValue: "0000000000000000000000000000000000000000000000000858898f93629000",
+        structLogs: [
+          %{
+            depth: 1,
+            gas: 599978568,
+            gasCost: 3,
+            op: "PUSH1",
+            pc: 0,
+            stack: []
+          },
+          %{
+            depth: 1,
+            gas: 599978565,
+            gasCost: 3,
+            op: "PUSH1",
+            pc: 2,
+            stack: ["0x80"]
+          },
+          %{
+            depth: 1,
+            gas: 599978562,
+            gasCost: 12,
+            op: "MSTORE",
+            pc: 4,
+            stack: ["0x80", "0x40"]
+          }
+        ]
+      }
+  """
+  @spec serialize(t()) :: map()
+  def serialize(debug_trace) do
+    %{
+      failed: debug_trace.failed,
+      gas: debug_trace.gas,
+      returnValue: String.replace_prefix(to_hex(debug_trace.return_value), "0x", ""),
+      structLogs: Enum.map(debug_trace.struct_logs, &StructLog.serialize/1)
     }
   end
 end

--- a/lib/signet/trace_call.ex
+++ b/lib/signet/trace_call.ex
@@ -121,11 +121,131 @@ defmodule Signet.TraceCall do
         vm_trace: nil
       }
   """
-  @spec deserialize(map()) :: [Signet.TraceCall.t()] | no_return()
+  @spec deserialize(map()) :: t() | no_return()
   def deserialize(%{"output" => output, "trace" => trace}) do
     %__MODULE__{
       output: from_hex!(output),
       trace: Signet.Trace.deserialize_many(trace)
+    }
+  end
+
+  @doc ~S"""
+  Deserializes a single of trace result from `trace_callMany`.
+
+  ## Examples
+
+      iex> use Signet.Hex
+      iex> %Signet.TraceCall{
+      ...>   output: "",
+      ...>   state_diff: nil,
+      ...>   trace: [
+      ...>     %Signet.Trace{
+      ...>       action: %Signet.Trace.Action{
+      ...>         call_type: "call",
+      ...>         init: nil,
+      ...>         from: ~h[0x0000000000000000000000000000000000000000],
+      ...>         gas: 499_978_072,
+      ...>         input: ~h[0xd1692f56000000000000000000000000142da9114e5a98e015aa95afca0585e84832a612000000000000000000000000142da9114e5a98e015aa95afca0585e84832a6120000000000000000000000000000000000000000000000000000000000000000],
+      ...>         to: ~h[0x13172ee393713fba9925a9a752341ebd31e8d9a7],
+      ...>         value: 0
+      ...>       },
+      ...>       block_hash: nil,
+      ...>       block_number: nil,
+      ...>       gas_used: 492_166_471,
+      ...>       error: "Reverted",
+      ...>       output: "",
+      ...>       result_code: nil,
+      ...>       result_address: nil,
+      ...>       subtraces: 1,
+      ...>       trace_address: [],
+      ...>       transaction_hash: nil,
+      ...>       transaction_position: nil,
+      ...>       type: "call"
+      ...>     },
+      ...>     %Signet.Trace{
+      ...>       action: %Signet.Trace.Action{
+      ...>         call_type: nil,
+      ...>         init: ~h[0x60e03461009157601f6101ec38819003918201601f19168301916001600160401b038311848410176100965780849260609460405283398101031261009157610047816100ac565b906100606040610059602084016100ac565b92016100ac565b9060805260a05260c05260405161012b90816100c18239608051816088015260a051816045015260c0518160c60152f35b600080fd5b634e487b7160e01b600052604160045260246000fd5b51906001600160a01b03821682036100915756fe608060405260043610156013575b3660ba57005b6000803560e01c8063238ac9331460775763c34c08e51460325750600d565b34607457806003193601126074576040517f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03168152602090f35b80fd5b5034607457806003193601126074577f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03166080908152602090f35b600036818037808036817f00000000000000000000000000000000000000000000000000000000000000005af4903d918282803e60f357fd5bf3fea264697066735822122032b5603d6937ceb7a252e16379744d8545670ff4978c8d76c985d051dfcfe46c64736f6c6343000817003300000000000000000000000049e5d261e95f6a02505078bb339fecb210a0b634000000000000000000000000142da9114e5a98e015aa95afca0585e84832a612000000000000000000000000142da9114e5a98e015aa95afca0585e84832a612],
+      ...>         from: ~h[0x13172ee393713fba9925a9a752341ebd31e8d9a7],
+      ...>         gas: 492_133_529,
+      ...>         input: nil,
+      ...>         to: nil,
+      ...>         value: 0
+      ...>       },
+      ...>       block_hash: nil,
+      ...>       block_number: nil,
+      ...>       gas_used: nil,
+      ...>       error: "contract address collision",
+      ...>       output: nil,
+      ...>       result_code: nil,
+      ...>       result_address: nil,
+      ...>       subtraces: 0,
+      ...>       trace_address: [0],
+      ...>       transaction_hash: nil,
+      ...>       transaction_position: nil,
+      ...>       type: "create"
+      ...>     }
+      ...>   ],
+      ...>   vm_trace: nil
+      ...> }
+      ...> |> Signet.TraceCall.serialize()
+      %{
+        output: "0x",
+        stateDiff: nil,
+        trace: [
+          %{
+            action: %{
+              callType: "call",
+              from: "0x0000000000000000000000000000000000000000",
+              gas: "0x1DCD0F58",
+              input:
+                "0xd1692f56000000000000000000000000142da9114e5a98e015aa95afca0585e84832a612000000000000000000000000142da9114e5a98e015aa95afca0585e84832a6120000000000000000000000000000000000000000000000000000000000000000",
+              to: "0x13172EE393713fbA9925A9A752341Ebd31e8D9a7",
+              value: "0x0",
+              init: nil
+            },
+            error: "Reverted",
+            result: %{gasUsed: "0x1D55DD47", output: "0x", address: nil, code: nil},
+            subtraces: 1,
+            traceAddress: [],
+            type: "call",
+            blockHash: nil,
+            blockNumber: nil,
+            transactionHash: nil,
+            transactionPosition: nil
+          },
+          %{
+            action: %{
+              from: "0x13172EE393713fbA9925A9A752341Ebd31e8D9a7",
+              gas: "0x1D555C99",
+              init:
+                "0x60e03461009157601f6101ec38819003918201601f19168301916001600160401b038311848410176100965780849260609460405283398101031261009157610047816100ac565b906100606040610059602084016100ac565b92016100ac565b9060805260a05260c05260405161012b90816100c18239608051816088015260a051816045015260c0518160c60152f35b600080fd5b634e487b7160e01b600052604160045260246000fd5b51906001600160a01b03821682036100915756fe608060405260043610156013575b3660ba57005b6000803560e01c8063238ac9331460775763c34c08e51460325750600d565b34607457806003193601126074576040517f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03168152602090f35b80fd5b5034607457806003193601126074577f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03166080908152602090f35b600036818037808036817f00000000000000000000000000000000000000000000000000000000000000005af4903d918282803e60f357fd5bf3fea264697066735822122032b5603d6937ceb7a252e16379744d8545670ff4978c8d76c985d051dfcfe46c64736f6c6343000817003300000000000000000000000049e5d261e95f6a02505078bb339fecb210a0b634000000000000000000000000142da9114e5a98e015aa95afca0585e84832a612000000000000000000000000142da9114e5a98e015aa95afca0585e84832a612",
+              value: "0x0",
+              callType: nil,
+              input: nil,
+              to: nil
+            },
+            error: "contract address collision",
+            result: %{code: nil, output: nil, address: nil, gasUsed: nil},
+            subtraces: 0,
+            traceAddress: [0],
+            type: "create",
+            blockHash: nil,
+            blockNumber: nil,
+            transactionHash: nil,
+            transactionPosition: nil
+          }
+        ],
+        vmTrace: nil
+      }
+  """
+  @spec serialize(t()) :: map()
+  def serialize(trace_call) do
+    %{
+      output: to_hex(trace_call.output),
+      stateDiff: trace_call.state_diff,
+      vmTrace: trace_call.vm_trace,
+      trace: Enum.map(trace_call.trace, &Signet.Trace.serialize/1)
     }
   end
 

--- a/lib/signet/util.ex
+++ b/lib/signet/util.ex
@@ -458,4 +458,8 @@ defmodule Signet.Util do
       end
     end
   end
+
+  @doc false
+  def nil_map(nil, _), do: nil
+  def nil_map(x, fun), do: fun.(x)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.2.7",
+      version: "1.2.8",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch adds the opposite of `trace.deserialize()` which allows us to re-serialize a JSON (be it a call trace, a trace trx or a debug trace). These are useful for generally printing or showing traces, which can be difficult due to the amount of Elixir-binaries that usually show up.