### PR TITLE
Warn on Invalid RPC Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.2.8"}
+    {:signet, "~> 1.2.9"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.2.8",
+      version: "1.2.9",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/client.ex
+++ b/test/support/client.ex
@@ -792,6 +792,15 @@ defmodule Signet.Test.Client do
      }}
   end
 
+  # Call that fails with invalid params
+  def eth_call(_trx = %{"to" => "0x000000000000000000000000000000000000000D"}, _block) do
+    {:error,
+     %{
+       "code" => -32602,
+       "message" => "Failed to decode transaction"
+     }}
+  end
+
   # Sleuth call
   # Sleuth call - Facts Query
   def eth_call(


### PR DESCRIPTION
This patch warns for invalid JSON-RPC requests. These requests can be very hard to debug since it's often unclear what the invalid request was, so we log such requests for the user.

Bump to 1.2.9