### PR TITLE
feat: `Signet.Sleuth.query_v2` with more-obvious return types, supporting `:decode_structs` from `abi.ex` for better decoding

### DIFF
--- a/lib/signet/sleuth.ex
+++ b/lib/signet/sleuth.ex
@@ -80,6 +80,7 @@ defmodule Signet.Sleuth do
     |> then(fn
       processed_results when not be_obvious ->
         case processed_results do
+          [] -> []
           [{nil, result}] -> result
           [{"", result}] -> result
 

--- a/lib/signet/sleuth.ex
+++ b/lib/signet/sleuth.ex
@@ -46,20 +46,6 @@ defmodule Signet.Sleuth do
   end
 
   def query_v2(bytecode, query, selector, opts \\ []) do
-    opts =
-      Keyword.validate!(opts, [:sleuth_address, :decode_structs, :decode_binaries, :named_returns])
-
-    query_v2_internal(bytecode, query, selector, Keyword.put(opts, :annotated, false))
-  end
-
-  def query_v2_annotated(bytecode, query, selector, opts \\ []) do
-    opts =
-      Keyword.validate!(opts, [:sleuth_address, :decode_structs, :decode_binaries, :named_returns])
-
-    query_v2_internal(bytecode, query, selector, Keyword.put(opts, :annotated, true))
-  end
-
-  defp query_v2_internal(bytecode, query, selector, opts) do
     {annotated, opts} = Keyword.pop(opts, :annotated, false)
     {sleuth_address, opts} = Keyword.pop(opts, :sleuth_address, @sleuth_address)
     {decode_binaries, opts} = Keyword.pop(opts, :decode_binaries, true)

--- a/lib/signet/sleuth.ex
+++ b/lib/signet/sleuth.ex
@@ -30,13 +30,20 @@ defmodule Signet.Sleuth do
   defp query_internal(bytecode, query, selector, annotated, opts)
        when is_binary(bytecode) and is_list(opts) do
     {sleuth_address, opts} = Keyword.pop(opts, :sleuth_address, @sleuth_address)
-    {decode_binaries, rpc_opts} = Keyword.pop(opts, :decode_binaries, true)
+    {decode_binaries, opts} = Keyword.pop(opts, :decode_binaries, true)
+    {decode_structs, opts} = Keyword.pop(opts, :decode_structs, false)
+    {be_obvious, rpc_opts} = Keyword.pop(opts, :be_obvious, decode_structs)
 
     with {:ok, query_res_bytes} <-
            Signet.Contract.Sleuth.call_query(sleuth_address, bytecode, query, rpc_opts),
          {:ok, query_res} <- try_decode_bytes(query_res_bytes),
-         {:ok, res} <- try_decode(query_res, selector) do
-      {:ok, unwrap_outer_tuple(encode_map(res, selector.returns, annotated, decode_binaries))}
+         {:ok, res} <- try_decode(query_res, selector, decode_structs) do
+      {:ok,
+       postprocess(res, selector.returns,
+         annotated: annotated,
+         decode_binaries: decode_binaries,
+         be_obvious: be_obvious
+       )}
     end
   end
 
@@ -50,76 +57,111 @@ defmodule Signet.Sleuth do
     end
   end
 
-  defp try_decode(query_res, selector) do
+  defp try_decode(query_res, selector, decode_structs) do
     try do
-      {:ok, ABI.decode(%ABI.FunctionSelector{types: selector.returns}, query_res)}
+      {:ok,
+       ABI.decode(
+         %ABI.FunctionSelector{types: selector.returns},
+         query_res,
+         decode_structs: decode_structs
+       )}
     rescue
       e ->
         {:error, "error decoding: #{inspect(e)}"}
     end
   end
 
-  defp encode_map(res, types, annotated, decode_binaries) do
-    Enum.map(Enum.zip(res, Enum.with_index(types)), fn {res, {type, i}} ->
-      encode_item(res, type, i, annotated, decode_binaries)
+  defp postprocess(results, named_types, opts) when is_list(results) and is_list(named_types) do
+    be_obvious = Keyword.get(opts, :be_obvious, false)
+
+    results
+    |> Enum.zip(named_types)
+    |> Enum.map(fn {it, t} -> {t.name, postprocess(it, t.type, opts)} end)
+    |> then(fn
+      processed_results when not be_obvious ->
+        case processed_results do
+          [{nil, result}] -> result
+          [{"", result}] -> result
+
+          [_more | _than_one] = processed_results ->
+            processed_results
+            |> Enum.with_index()
+            |> Enum.map(fn {{name, it}, i} ->
+              name =
+                if is_nil(name) or name == "" do
+                  "var#{i}"
+                else
+                  name
+                end
+
+              {name, it}
+            end)
+            |> Enum.into(%{})
+        end
+
+      processed_results when be_obvious ->
+        Enum.map(processed_results, fn {_, v} -> v end)
+    end)
+  end
+
+  defp postprocess(item, {:tuple, named_types}, opts)
+       when is_tuple(item) and is_list(named_types) do
+    atomize = Keyword.get(opts, :atomize, false)
+
+    item
+    |> Tuple.to_list()
+    |> Enum.zip(named_types)
+    |> Enum.map(fn {item, %{type: type, name: name}} ->
+      name =
+        if not is_atom(name) and atomize do
+          String.to_atom(Macro.underscore(name))
+        else
+          name
+        end
+
+      {name, postprocess(item, type, opts)}
     end)
     |> Enum.into(%{})
   end
 
-  defp encode_item(res, type, i, annotated, decode_binaries) do
-    var_name =
-      if is_nil(type.name) or type.name == "" do
-        "var#{i}"
+  defp postprocess(item, {:tuple, named_types}, opts)
+       when is_map(item) and is_list(named_types) do
+    item
+    |> Enum.map(fn {k, v} ->
+      %{type: type} =
+        Enum.find(named_types, fn %{name: name} -> Macro.underscore(name) == to_string(k) end)
+
+      {k, postprocess(v, type, opts)}
+    end)
+    |> Enum.into(%{})
+  end
+
+  defp postprocess(item, {:array, type}, opts) when is_list(item) do
+    Enum.map(item, &postprocess(&1, type, opts))
+  end
+
+  defp postprocess(item, {:array, type, _}, opts) when is_list(item),
+    do: postprocess(item, {:array, type}, opts)
+
+  defp postprocess(item, type, opts) do
+    item_encoded =
+      if not Keyword.get(opts, :decode_binaries, true) do
+        case type do
+          :address -> to_hex(item)
+          :bytes -> to_hex(item)
+          {:bytes, _size} -> to_hex(item)
+          _nonbinary_scalar -> item
+        end
       else
-        type.name
+        item
       end
 
-    res_enc = encode_value(res, type.type, annotated, decode_binaries)
-
-    {var_name, res_enc}
-  end
-
-  defp encode_value(res, type, annotated, decode_binaries) do
-    encode_array = fn sub_type ->
-      Enum.map(res, fn r -> encode_value(r, sub_type, annotated, decode_binaries) end)
-    end
-
-    case type do
-      {:tuple, sub_types} ->
-        encode_map(Tuple.to_list(res), sub_types, annotated, decode_binaries)
-
-      {:array, sub_type} ->
-        encode_array.(sub_type)
-
-      {:array, sub_type, _} ->
-        encode_array.(sub_type)
-
-      _ ->
-        res_enc =
-          case {type, decode_binaries} do
-            {:address, false} ->
-              to_hex(res)
-
-            {:bytes, false} ->
-              to_hex(res)
-
-            {{:bytes, _size}, false} ->
-              to_hex(res)
-
-            _ ->
-              res
-          end
-
-        if annotated do
-          {type, res_enc}
-        else
-          res_enc
-        end
+    if Keyword.get(opts, :annotated, false) do
+      {type, item_encoded}
+    else
+      item_encoded
     end
   end
-
-  defp unwrap_outer_tuple(xs = %{"var0" => x}) when map_size(xs) == 1, do: x
-  defp unwrap_outer_tuple(els), do: els
 
   defp try_apply(mod, fun, args) do
     try do

--- a/lib/signet/sleuth.ex
+++ b/lib/signet/sleuth.ex
@@ -107,19 +107,10 @@ defmodule Signet.Sleuth do
 
   defp postprocess(item, {:tuple, named_types}, opts)
        when is_tuple(item) and is_list(named_types) do
-    atomize = Keyword.get(opts, :atomize, false)
-
     item
     |> Tuple.to_list()
     |> Enum.zip(named_types)
     |> Enum.map(fn {item, %{type: type, name: name}} ->
-      name =
-        if not is_atom(name) and atomize do
-          String.to_atom(Macro.underscore(name))
-        else
-          name
-        end
-
       {name, postprocess(item, type, opts)}
     end)
     |> Enum.into(%{})

--- a/test/sleuth_test.exs
+++ b/test/sleuth_test.exs
@@ -12,6 +12,14 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.encode_query(),
                  Signet.Contract.BlockNumber.query_selector()
                )
+
+      assert {:ok, [2]} ==
+               Signet.Sleuth.query(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query(),
+                 Signet.Contract.BlockNumber.query_selector(),
+                 be_obvious: true
+               )
     end
 
     test "query() failure with trace" do
@@ -51,11 +59,21 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber,
                  :query
                )
+
+      assert {:ok, [2]} ==
+               Signet.Sleuth.query_by(
+                 Signet.Contract.BlockNumber,
+                 :query,
+                 be_obvious: true
+               )
     end
 
     test "query_by() via mod" do
       assert {:ok, %{"blockNumber" => 2}} ==
                Signet.Sleuth.query_by(Signet.Contract.BlockNumber)
+
+      assert {:ok, [2]} ==
+               Signet.Sleuth.query_by(Signet.Contract.BlockNumber, be_obvious: true)
     end
 
     test "queryTwo()" do
@@ -64,6 +82,14 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.bytecode(),
                  Signet.Contract.BlockNumber.encode_query_two(),
                  Signet.Contract.BlockNumber.query_two_selector()
+               )
+
+      assert {:ok, [2, 3]} ==
+               Signet.Sleuth.query(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_two(),
+                 Signet.Contract.BlockNumber.query_two_selector(),
+                 be_obvious: true
                )
     end
 
@@ -74,6 +100,14 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.encode_query_two(),
                  Signet.Contract.BlockNumber.query_two_selector()
                )
+
+      assert {:ok, [{{:uint, 256}, 2}, {{:uint, 256}, 3}]} ==
+               Signet.Sleuth.query_annotated(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_two(),
+                 Signet.Contract.BlockNumber.query_two_selector(),
+                 be_obvious: true
+               )
     end
 
     test "queryThree()" do
@@ -82,6 +116,14 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.bytecode(),
                  Signet.Contract.BlockNumber.encode_query_three(),
                  Signet.Contract.BlockNumber.query_three_selector()
+               )
+
+      assert {:ok, [2]} ==
+               Signet.Sleuth.query(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_three(),
+                 Signet.Contract.BlockNumber.query_three_selector(),
+                 be_obvious: true
                )
     end
 
@@ -92,6 +134,14 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.encode_query_three(),
                  Signet.Contract.BlockNumber.query_three_selector()
                )
+
+      assert {:ok, [{{:uint, 256}, 2}]} ==
+               Signet.Sleuth.query_annotated(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_three(),
+                 Signet.Contract.BlockNumber.query_three_selector(),
+                 be_obvious: true
+               )
     end
 
     test "queryFour()" do
@@ -100,6 +150,14 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.bytecode(),
                  Signet.Contract.BlockNumber.encode_query_four(),
                  Signet.Contract.BlockNumber.query_four_selector()
+               )
+
+      assert {:ok, [~h[0x010203], <<1::160>>]} ==
+               Signet.Sleuth.query(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_four(),
+                 Signet.Contract.BlockNumber.query_four_selector(),
+                 be_obvious: true
                )
     end
 
@@ -111,6 +169,15 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.encode_query_four(),
                  Signet.Contract.BlockNumber.query_four_selector(),
                  decode_binaries: false
+               )
+
+      assert {:ok, ["0x010203", "0x0000000000000000000000000000000000000001"]} ==
+               Signet.Sleuth.query(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_four(),
+                 Signet.Contract.BlockNumber.query_four_selector(),
+                 decode_binaries: false,
+                 be_obvious: true
                )
     end
 
@@ -128,6 +195,21 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.encode_query_cool(),
                  Signet.Contract.BlockNumber.query_cool_selector()
                )
+
+      assert {:ok,
+              [
+                %{
+                  "fun" => %{"cat" => "meow"},
+                  "x" => "hi",
+                  "ys" => [1, 2, 3]
+                }
+              ]} ==
+               Signet.Sleuth.query(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_cool(),
+                 Signet.Contract.BlockNumber.query_cool_selector(),
+                 be_obvious: true
+               )
     end
 
     test "queryCool() - annotated" do
@@ -143,6 +225,21 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.bytecode(),
                  Signet.Contract.BlockNumber.encode_query_cool(),
                  Signet.Contract.BlockNumber.query_cool_selector()
+               )
+
+      assert {:ok,
+              [
+                %{
+                  "fun" => %{"cat" => {:string, "meow"}},
+                  "x" => {:string, "hi"},
+                  "ys" => [{{:uint, 256}, 1}, {{:uint, 256}, 2}, {{:uint, 256}, 3}]
+                }
+              ]} ==
+               Signet.Sleuth.query_annotated(
+                 Signet.Contract.BlockNumber.bytecode(),
+                 Signet.Contract.BlockNumber.encode_query_cool(),
+                 Signet.Contract.BlockNumber.query_cool_selector(),
+                 be_obvious: true
                )
     end
   end

--- a/test/sleuth_test.exs
+++ b/test/sleuth_test.exs
@@ -13,13 +13,17 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.query_selector()
                )
 
-      assert {:ok, [2]} ==
-               Signet.Sleuth.query(
-                 Signet.Contract.BlockNumber.bytecode(),
-                 Signet.Contract.BlockNumber.encode_query(),
-                 Signet.Contract.BlockNumber.query_selector(),
-                 be_obvious: true
-               )
+      v2_case = fn opts ->
+        Signet.Sleuth.query_v2(
+          Signet.Contract.BlockNumber.bytecode(),
+          Signet.Contract.BlockNumber.encode_query(),
+          Signet.Contract.BlockNumber.query_selector(),
+          opts
+        )
+      end
+
+      assert {:ok, [2]} == v2_case.([])
+      assert {:ok, [block_number: 2]} == v2_case.(named_returns: true)
     end
 
     test "query() failure with trace" do
@@ -59,21 +63,11 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber,
                  :query
                )
-
-      assert {:ok, [2]} ==
-               Signet.Sleuth.query_by(
-                 Signet.Contract.BlockNumber,
-                 :query,
-                 be_obvious: true
-               )
     end
 
     test "query_by() via mod" do
       assert {:ok, %{"blockNumber" => 2}} ==
                Signet.Sleuth.query_by(Signet.Contract.BlockNumber)
-
-      assert {:ok, [2]} ==
-               Signet.Sleuth.query_by(Signet.Contract.BlockNumber, be_obvious: true)
     end
 
     test "queryTwo()" do
@@ -84,13 +78,17 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.query_two_selector()
                )
 
-      assert {:ok, [2, 3]} ==
-               Signet.Sleuth.query(
-                 Signet.Contract.BlockNumber.bytecode(),
-                 Signet.Contract.BlockNumber.encode_query_two(),
-                 Signet.Contract.BlockNumber.query_two_selector(),
-                 be_obvious: true
-               )
+      v2_case = fn opts ->
+        Signet.Sleuth.query_v2(
+          Signet.Contract.BlockNumber.bytecode(),
+          Signet.Contract.BlockNumber.encode_query_two(),
+          Signet.Contract.BlockNumber.query_two_selector(),
+          opts
+        )
+      end
+
+      assert {:ok, [2, 3]} == v2_case.([])
+      assert {:ok, [x: 2, y: 3]} == v2_case.(named_returns: true)
     end
 
     test "queryTwo() - annotated" do
@@ -101,13 +99,19 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.query_two_selector()
                )
 
-      assert {:ok, [{{:uint, 256}, 2}, {{:uint, 256}, 3}]} ==
-               Signet.Sleuth.query_annotated(
-                 Signet.Contract.BlockNumber.bytecode(),
-                 Signet.Contract.BlockNumber.encode_query_two(),
-                 Signet.Contract.BlockNumber.query_two_selector(),
-                 be_obvious: true
-               )
+      v2_annotated_case = fn opts ->
+        Signet.Sleuth.query_v2_annotated(
+          Signet.Contract.BlockNumber.bytecode(),
+          Signet.Contract.BlockNumber.encode_query_two(),
+          Signet.Contract.BlockNumber.query_two_selector(),
+          opts
+        )
+      end
+
+      assert {:ok, [{{:uint, 256}, 2}, {{:uint, 256}, 3}]} == v2_annotated_case.([])
+
+      assert {:ok, [x: {{:uint, 256}, 2}, y: {{:uint, 256}, 3}]} ==
+               v2_annotated_case.(named_returns: true)
     end
 
     test "queryThree()" do
@@ -118,13 +122,17 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.query_three_selector()
                )
 
-      assert {:ok, [2]} ==
-               Signet.Sleuth.query(
-                 Signet.Contract.BlockNumber.bytecode(),
-                 Signet.Contract.BlockNumber.encode_query_three(),
-                 Signet.Contract.BlockNumber.query_three_selector(),
-                 be_obvious: true
-               )
+      v2_case = fn opts ->
+        Signet.Sleuth.query_v2(
+          Signet.Contract.BlockNumber.bytecode(),
+          Signet.Contract.BlockNumber.encode_query_three(),
+          Signet.Contract.BlockNumber.query_three_selector(),
+          opts
+        )
+      end
+
+      assert {:ok, [2]} == v2_case.([])
+      assert {:ok, [__unnamed__: 2]} == v2_case.(named_returns: true)
     end
 
     test "queryThree() - annotated" do
@@ -136,11 +144,10 @@ defmodule SleuthTest do
                )
 
       assert {:ok, [{{:uint, 256}, 2}]} ==
-               Signet.Sleuth.query_annotated(
+               Signet.Sleuth.query_v2_annotated(
                  Signet.Contract.BlockNumber.bytecode(),
                  Signet.Contract.BlockNumber.encode_query_three(),
-                 Signet.Contract.BlockNumber.query_three_selector(),
-                 be_obvious: true
+                 Signet.Contract.BlockNumber.query_three_selector()
                )
     end
 
@@ -152,13 +159,19 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.query_four_selector()
                )
 
-      assert {:ok, [~h[0x010203], <<1::160>>]} ==
-               Signet.Sleuth.query(
-                 Signet.Contract.BlockNumber.bytecode(),
-                 Signet.Contract.BlockNumber.encode_query_four(),
-                 Signet.Contract.BlockNumber.query_four_selector(),
-                 be_obvious: true
-               )
+      v2_case = fn opts ->
+        Signet.Sleuth.query_v2(
+          Signet.Contract.BlockNumber.bytecode(),
+          Signet.Contract.BlockNumber.encode_query_four(),
+          Signet.Contract.BlockNumber.query_four_selector(),
+          opts
+        )
+      end
+
+      assert {:ok, [~h[0x010203], <<1::160>>]} == v2_case.([])
+
+      assert {:ok, [__unnamed__: ~h[0x010203], __unnamed__: <<1::160>>]} ==
+               v2_case.(named_returns: true)
     end
 
     test "queryFour() - no decode binaries" do
@@ -171,14 +184,21 @@ defmodule SleuthTest do
                  decode_binaries: false
                )
 
+      v2_case = fn opts ->
+        Signet.Sleuth.query_v2(
+          Signet.Contract.BlockNumber.bytecode(),
+          Signet.Contract.BlockNumber.encode_query_four(),
+          Signet.Contract.BlockNumber.query_four_selector(),
+          opts
+        )
+      end
+
       assert {:ok, ["0x010203", "0x0000000000000000000000000000000000000001"]} ==
-               Signet.Sleuth.query(
-                 Signet.Contract.BlockNumber.bytecode(),
-                 Signet.Contract.BlockNumber.encode_query_four(),
-                 Signet.Contract.BlockNumber.query_four_selector(),
-                 decode_binaries: false,
-                 be_obvious: true
-               )
+               v2_case.(decode_binaries: false)
+
+      assert {:ok,
+              [__unnamed__: "0x010203", __unnamed__: "0x0000000000000000000000000000000000000001"]} ==
+               v2_case.(decode_binaries: false, named_returns: true)
     end
 
     test "queryCool()" do
@@ -196,6 +216,24 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.query_cool_selector()
                )
 
+      v2_case = fn opts ->
+        Signet.Sleuth.query_v2(
+          Signet.Contract.BlockNumber.bytecode(),
+          Signet.Contract.BlockNumber.encode_query_cool(),
+          Signet.Contract.BlockNumber.query_cool_selector(),
+          opts
+        )
+      end
+
+      assert {:ok,
+              [
+                %{
+                  fun: %{cat: "meow"},
+                  x: "hi",
+                  ys: [1, 2, 3]
+                }
+              ]} == v2_case.([])
+
       assert {:ok,
               [
                 %{
@@ -203,13 +241,25 @@ defmodule SleuthTest do
                   "x" => "hi",
                   "ys" => [1, 2, 3]
                 }
-              ]} ==
-               Signet.Sleuth.query(
-                 Signet.Contract.BlockNumber.bytecode(),
-                 Signet.Contract.BlockNumber.encode_query_cool(),
-                 Signet.Contract.BlockNumber.query_cool_selector(),
-                 be_obvious: true
-               )
+              ]} == v2_case.(decode_structs: false)
+
+      assert {:ok,
+              [
+                cool: %{
+                  fun: %{cat: "meow"},
+                  x: "hi",
+                  ys: [1, 2, 3]
+                }
+              ]} == v2_case.(named_returns: true)
+
+      assert {:ok,
+              [
+                cool: %{
+                  "fun" => %{"cat" => "meow"},
+                  "x" => "hi",
+                  "ys" => [1, 2, 3]
+                }
+              ]} == v2_case.(named_returns: true, decode_structs: false)
     end
 
     test "queryCool() - annotated" do
@@ -227,6 +277,24 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.query_cool_selector()
                )
 
+      v2_annotated_case = fn opts ->
+        Signet.Sleuth.query_v2_annotated(
+          Signet.Contract.BlockNumber.bytecode(),
+          Signet.Contract.BlockNumber.encode_query_cool(),
+          Signet.Contract.BlockNumber.query_cool_selector(),
+          opts
+        )
+      end
+
+      assert {:ok,
+              [
+                %{
+                  fun: %{cat: {:string, "meow"}},
+                  x: {:string, "hi"},
+                  ys: [{{:uint, 256}, 1}, {{:uint, 256}, 2}, {{:uint, 256}, 3}]
+                }
+              ]} == v2_annotated_case.([])
+
       assert {:ok,
               [
                 %{
@@ -234,13 +302,16 @@ defmodule SleuthTest do
                   "x" => {:string, "hi"},
                   "ys" => [{{:uint, 256}, 1}, {{:uint, 256}, 2}, {{:uint, 256}, 3}]
                 }
-              ]} ==
-               Signet.Sleuth.query_annotated(
-                 Signet.Contract.BlockNumber.bytecode(),
-                 Signet.Contract.BlockNumber.encode_query_cool(),
-                 Signet.Contract.BlockNumber.query_cool_selector(),
-                 be_obvious: true
-               )
+              ]} == v2_annotated_case.(decode_structs: false)
+
+      assert {:ok,
+              [
+                cool: %{
+                  "fun" => %{"cat" => {:string, "meow"}},
+                  "x" => {:string, "hi"},
+                  "ys" => [{{:uint, 256}, 1}, {{:uint, 256}, 2}, {{:uint, 256}, 3}]
+                }
+              ]} == v2_annotated_case.(decode_structs: false, named_returns: true)
     end
   end
 end

--- a/test/sleuth_test.exs
+++ b/test/sleuth_test.exs
@@ -1,7 +1,9 @@
 defmodule SleuthTest do
   use ExUnit.Case
   use Signet.Hex
+
   alias Signet.Sleuth
+
   doctest Sleuth
 
   describe "BlockNumber" do
@@ -99,8 +101,8 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.query_two_selector()
                )
 
-      v2_annotated_case = fn opts ->
-        Signet.Sleuth.query_v2_annotated(
+      v2_case = fn opts ->
+        Signet.Sleuth.query_v2(
           Signet.Contract.BlockNumber.bytecode(),
           Signet.Contract.BlockNumber.encode_query_two(),
           Signet.Contract.BlockNumber.query_two_selector(),
@@ -108,10 +110,10 @@ defmodule SleuthTest do
         )
       end
 
-      assert {:ok, [{{:uint, 256}, 2}, {{:uint, 256}, 3}]} == v2_annotated_case.([])
+      assert {:ok, [{{:uint, 256}, 2}, {{:uint, 256}, 3}]} == v2_case.(annotated: true)
 
       assert {:ok, [x: {{:uint, 256}, 2}, y: {{:uint, 256}, 3}]} ==
-               v2_annotated_case.(named_returns: true)
+               v2_case.(annotated: true, named_returns: true)
     end
 
     test "queryThree()" do
@@ -144,10 +146,11 @@ defmodule SleuthTest do
                )
 
       assert {:ok, [{{:uint, 256}, 2}]} ==
-               Signet.Sleuth.query_v2_annotated(
+               Signet.Sleuth.query_v2(
                  Signet.Contract.BlockNumber.bytecode(),
                  Signet.Contract.BlockNumber.encode_query_three(),
-                 Signet.Contract.BlockNumber.query_three_selector()
+                 Signet.Contract.BlockNumber.query_three_selector(),
+                 annotated: true
                )
     end
 
@@ -277,8 +280,8 @@ defmodule SleuthTest do
                  Signet.Contract.BlockNumber.query_cool_selector()
                )
 
-      v2_annotated_case = fn opts ->
-        Signet.Sleuth.query_v2_annotated(
+      v2_case = fn opts ->
+        Signet.Sleuth.query_v2(
           Signet.Contract.BlockNumber.bytecode(),
           Signet.Contract.BlockNumber.encode_query_cool(),
           Signet.Contract.BlockNumber.query_cool_selector(),
@@ -293,7 +296,7 @@ defmodule SleuthTest do
                   x: {:string, "hi"},
                   ys: [{{:uint, 256}, 1}, {{:uint, 256}, 2}, {{:uint, 256}, 3}]
                 }
-              ]} == v2_annotated_case.([])
+              ]} == v2_case.(annotated: true)
 
       assert {:ok,
               [
@@ -302,7 +305,7 @@ defmodule SleuthTest do
                   "x" => {:string, "hi"},
                   "ys" => [{{:uint, 256}, 1}, {{:uint, 256}, 2}, {{:uint, 256}, 3}]
                 }
-              ]} == v2_annotated_case.(decode_structs: false)
+              ]} == v2_case.(annotated: true, decode_structs: false)
 
       assert {:ok,
               [
@@ -311,7 +314,7 @@ defmodule SleuthTest do
                   "x" => {:string, "hi"},
                   "ys" => [{{:uint, 256}, 1}, {{:uint, 256}, 2}, {{:uint, 256}, 3}]
                 }
-              ]} == v2_annotated_case.(decode_structs: false, named_returns: true)
+              ]} == v2_case.(annotated: true, decode_structs: false, named_returns: true)
     end
   end
 end


### PR DESCRIPTION
so, some things happened.

1. i realized that ABI.decode(...) takes a decode_structs opt that
   decodes function selector return values into nice atom-keyed maps!

2. i wanted it, because it would let me delete some annoying kludge code
   in legend-api. recall an earlier PR where i modified the encoder to
   allow string keys? same problem, but now better solution, because the
   client can just decode_structs and then they can use encode_query()
   like normal, instead of manually ABI.encode(...)ing and not
   benefiting from the codegen.

3. i realized that the way Signet.Sleuth decodes named returns and
   multiple function returns is... really weird. so i added a
   "be_obvious" codepath that doesn't do all that. i never want to see
   "var0" and "var1" again.

4. i made it so that using decode_structs automatically also turns on
   be_obvious, so that when you opt into better decoding you also get
   more obvious return types.

it seems like all the decoding awkwardness comes from wanting to
preserve named returns, and then not knowing what to do (?) when some
returns are named and some are not.

but i don't care about named returns. i only care about named struct
fields. i don't think anyone should care about named returns, because
they're dumb -- just return a struct if you want a struct. so be_obvious
just ignores type names for named returns, and does the obvious thing:
decode each return value into an array.