### PR TITLE
use finch request correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.3.1"}
+    {:signet, "~> 1.3.2"}
   ]
 end
 ```

--- a/lib/signet/application.ex
+++ b/lib/signet/application.ex
@@ -16,7 +16,15 @@ defmodule Signet.Application do
   def start(_type, _args) do
     signers = Application.get_env(:signet, :signer, [])
 
-    children = Enum.map(signers, &get_signer_spec/1) ++ [{Finch, name: SignetFinch}]
+    finch_name = Application.get_env(:signet, :finch_name, SignetFinch)
+    # start a finch process by default
+    finch_child = if Application.get_env(:signet, :start_finch, true) do
+      [{Finch, name: finch_name}]
+    else
+      []
+    end
+
+    children = Enum.map(signers, &get_signer_spec/1) ++ finch_child
 
     opts = [strategy: :one_for_one, name: Signet.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/signet/open_chain.ex
+++ b/lib/signet/open_chain.ex
@@ -60,9 +60,10 @@ defmodule Signet.OpenChain do
   end
 
   defmodule API do
-    def http_client(), do: Application.get_env(:signet, :open_chain_client, SignetFinch)
+    def http_client(), do: Application.get_env(:signet, :open_chain_client, Finch)
 
     @base_url Application.compile_env(:signet, :open_chain_base_url, "https://api.openchain.xyz")
+    @finch_name Application.compile_env(:signet, :finch_name, SignetFinch)
 
     @spec get(String.t(), Keyword.t()) :: {:ok, term()} | {:error, String.t()}
     def get(url, opts) do
@@ -71,7 +72,7 @@ defmodule Signet.OpenChain do
 
       request = Finch.build(:get, url, headers)
 
-      case http_client().request(request,receive_timeout: timeout) do
+      case http_client().request(request, @finch_name, receive_timeout: timeout) do
         {:ok, %Finch.Response{status: code, body: resp_body}} when code in 200..299 ->
           case Jason.decode(resp_body) do
             {:ok, resp} ->

--- a/lib/signet/rpc.ex
+++ b/lib/signet/rpc.ex
@@ -10,6 +10,7 @@ defmodule Signet.RPC do
 
   defp ethereum_node(), do: Signet.Application.ethereum_node()
   defp http_client(), do: Signet.Application.http_client()
+  @finch_name Application.compile_env(:signet, :finch_name, SignetFinch)
 
   @default_gas_price nil
   @default_base_fee nil
@@ -157,7 +158,7 @@ defmodule Signet.RPC do
 
     request = Finch.build(:post, url, headers(headers), Jason.encode!(body))
 
-    case http_client().request(request, receive_timeout: timeout) do
+    case http_client().request(request, @finch_name, receive_timeout: timeout) do
       {:ok, %Finch.Response{status: code, body: resp_body}} when code in 200..299 ->
         with {:ok, result} <- decode_response(resp_body, body["id"], errors, method, body) do
           case decode do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.3.1",
+      version: "1.3.2",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/open_chain_test.exs
+++ b/test/open_chain_test.exs
@@ -25,7 +25,7 @@ defmodule Signet.OpenChainTest do
     }
     """
 
-    def request(%Finch.Request{method: "GET", host: "example.com", path: "/open-chain/signature-database/v1/lookup"}, _opts) do
+    def request(%Finch.Request{method: "GET", host: "example.com", path: "/open-chain/signature-database/v1/lookup"}, _finch_name, _opts) do
       {:ok, %Finch.Response{status: 200, body: @lookup_success}}
     end
   end

--- a/test/support/client.ex
+++ b/test/support/client.ex
@@ -15,7 +15,7 @@ defmodule Signet.Test.Client do
 
     {method, params, id}
   end
-  def request(%Finch.Request{body: body}, _opts) do
+  def request(%Finch.Request{body: body}, _finch_name, _opts) do
     {method, params, id} = parse_request(Jason.decode!(body))
 
     case apply(__MODULE__, String.to_atom(method), params) do


### PR DESCRIPTION
bugfix for 1.3.1, which did not pass the finch name to calling of Finch.request