### PR TITLE
Add Trace Opts, Bump to 1.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.3.7"}
+    {:signet, "~> 1.3.8"}
   ]
 end
 ```

--- a/lib/signet/filter.ex
+++ b/lib/signet/filter.ex
@@ -168,7 +168,7 @@ defmodule Signet.Filter do
           {logs, events} =
             raw_logs
             |> Enum.map(&Log.deserialize/1)
-            |> Enum.map(fn log -> %{ log | extra_data: extra_data} end)
+            |> Enum.map(fn log -> %{log | extra_data: extra_data} end)
             |> parse_events(decoders)
 
           for listener <- listeners, {event, log} <- events do

--- a/lib/signet/rpc.ex
+++ b/lib/signet/rpc.ex
@@ -302,6 +302,7 @@ defmodule Signet.RPC do
     errors = Keyword.get(opts, :errors, [])
     trace_reverts = Keyword.get(opts, :trace_reverts, false)
     debug_trace = Keyword.get(opts, :debug_trace, false)
+    trace_opts = Keyword.get(opts, :trace_opts, [])
 
     trx_res =
       send_rpc(
@@ -313,7 +314,7 @@ defmodule Signet.RPC do
       )
 
     if trace_reverts do
-      show_trace_revert(trx, trx_res, debug_trace, opts)
+      show_trace_revert(trx, trx_res, debug_trace, Keyword.merge(opts, trace_opts))
     else
       trx_res
     end
@@ -1356,6 +1357,7 @@ defmodule Signet.RPC do
     {signer, opts} = Keyword.pop(opts, :signer, Signet.Signer.Default)
     {trace_reverts, opts} = Keyword.pop(opts, :trace_reverts, false)
     {debug_trace, opts} = Keyword.pop(opts, :debug_trace, false)
+    {trace_opts, opts} = Keyword.pop(opts, :trace_opts, [])
 
     signer_address = Signet.Signer.address(signer)
     chain_id = Keyword.get_lazy(opts, :chain_id, fn -> Signet.Signer.chain_id(signer) end)
@@ -1400,7 +1402,7 @@ defmodule Signet.RPC do
       else
         trx_res ->
           if trace_reverts do
-            show_trace_revert(trx, trx_res, debug_trace, opts)
+            show_trace_revert(trx, trx_res, debug_trace, Keyword.merge(opts, trace_opts))
           else
             trx_res
           end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.3.7",
+      version: "1.3.8",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch adds `:trace_opts` for `trace_reverts`, which autoatically runs a trace on failed calls. These new opts allow for traces to use different opts, such as a different `ethereum_node`, since only certain node providers allow for traces.