### PR TITLE
add a few chain ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.3.8"}
+    {:signet, "~> 1.3.9"}
   ]
 end
 ```

--- a/lib/signet/util.ex
+++ b/lib/signet/util.ex
@@ -275,7 +275,15 @@ defmodule Signet.Util do
     optimism_sepolia: 11_155_420,
     world_chain: 480,
     world_chain_sepolia: 4801,
-    unichain: 130
+    unichain: 130,
+    avalanche: 43_114,
+    bnb_smart_chain: 56,
+    hyperevm: 999,
+    lens: 232,
+    polygon: 137,
+    sonic: 146,
+    ink: 57073,
+    plume: 98866
   }
 
   @doc ~S"""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.3.8",
+      version: "1.3.9",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This patch adds several chains to the chain id configuration.
     avalanche,
     bnb_smart_chain,
     hyperevm,
     lens,
     polygon,
     sonic,
     ink,
     plume