### PR TITLE
Allow custom default timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signet can be installed by adding `signet` to your list of dependencies in `mix.
 ```elixir
 def deps do
   [
-    {:signet, "~> 1.3.10"}
+    {:signet, "~> 1.3.11"}
   ]
 end
 ```

--- a/lib/signet/rpc.ex
+++ b/lib/signet/rpc.ex
@@ -11,6 +11,7 @@ defmodule Signet.RPC do
   defp ethereum_node(), do: Signet.Application.ethereum_node()
   defp http_client(), do: Signet.Application.http_client()
   @finch_name Application.compile_env(:signet, :finch_name, SignetFinch)
+  @default_timeout Application.compile_env(:signet, :timeout, 30_000)
 
   @default_gas_price nil
   @default_base_fee nil
@@ -152,7 +153,7 @@ defmodule Signet.RPC do
     headers = Keyword.get(opts, :headers, [])
     decode = Keyword.get(opts, :decode, nil)
     errors = Keyword.get(opts, :errors, nil)
-    timeout = Keyword.get(opts, :timeout, 30_000)
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
     verbose = Keyword.get(opts, :verbose, false)
     url = Keyword.get(opts, :ethereum_node, ethereum_node())
     id = Keyword.get_lazy(opts, :id, fn -> System.unique_integer([:positive]) end)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Signet.MixProject do
   def project do
     [
       app: :signet,
-      version: "1.3.10",
+      version: "1.3.11",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
We currently default the timeout to 30s. This allows the user of the library to specify a different default timeout value.